### PR TITLE
Use setup-python interpreter for Windows dependencies

### DIFF
--- a/.github/workflows/Test and publish.yml
+++ b/.github/workflows/Test and publish.yml
@@ -33,9 +33,8 @@ jobs:
     - name: Install system dependencies for Windows
       if: runner.os == 'Windows'
       run: |
-        choco install -y python
         python -m pip install --upgrade pip
-        pip install ".[test,lint,publish]"
+        python -m pip install ".[test,lint,publish]"
         python -c "from ldap3 import KERBEROS; print('KERBEROS OK')"
 
     - name: Display Python version


### PR DESCRIPTION
## Summary
- remove redundant `choco install -y python` from Windows job
- install extras with `python -m pip` to use `setup-python` interpreter

## Testing
- `python -m unittest discover -s src/tests -p "test_*.py" -v`


------
https://chatgpt.com/codex/tasks/task_b_6899e6ec257883248c62fd7ba9f820be