### PR TITLE
docs(#16): finalize AD modernization ADR rollout policy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -155,6 +155,9 @@ Agent expectations while executing a plan:
 - Commit immediately after each completed task.
 - Keep commits scoped to task boundaries with clear issue-linked messages.
 
+For AD response modernization and compatibility rollout work, follow ADR 0001 as the primary
+policy source: `docs/adr/0001-ad-response-modernization.md`.
+
 ---
 
 ### PR Skills (`pr-create`, `pr-comments`)

--- a/.github/skills/plan-issue/SKILL.md
+++ b/.github/skills/plan-issue/SKILL.md
@@ -148,7 +148,6 @@ Create `.planning/issue-{issue-number}-{short-name}.md`.
 
 **Files:**
 - `CHANGELOG.md`
-- (verification output only)
 
 **Acceptance criteria:**
 - Verification commands pass.

--- a/.github/skills/plan-issue/SKILL.md
+++ b/.github/skills/plan-issue/SKILL.md
@@ -45,7 +45,7 @@ Break the work into **phases** and **tasks**.
 - Group by shared context: tasks in a phase touch related files/concepts.
 - Keep phases small: aim for **2-5 tasks per phase**.
 - Order by dependency: earlier phases produce outputs later phases need.
-- **Every plan ends with a Cleanup phase** (build/test, verify, commit).
+- **Every plan ends with a Cleanup phase** (build/test, verify, changelog update, commit).
 
 **Suggested phase pattern**
 
@@ -54,7 +54,7 @@ Break the work into **phases** and **tasks**.
 | **0 - Setup** | Scaffolding, structural prep | Create files, registrations, models |
 | **1-N - Core** | Main feature/refactor | Implementation by context |
 | **N-1 - Polish** | Quality pass | Tests, edge cases, cleanup |
-| **N - Cleanup** | Finalize for PR | Verify, commit |
+| **N - Cleanup** | Finalize for PR | Verify, update `CHANGELOG.md`, commit |
 
 **Tasks**
 - Short, action-oriented name (3-8 words).
@@ -142,14 +142,17 @@ Create `.planning/issue-{issue-number}-{short-name}.md`.
 
 ## Phase N - Cleanup
 
-### Task N: Verify, test, and commit
+### Task N: Verify, test, update changelog, and commit
 
-**What:** Run project verification commands. Review changes and commit.
+**What:** Run project verification commands. Update `CHANGELOG.md` with a concise entry for the completed plan. Review changes and commit.
 
-**Files:** None (verification only).
+**Files:**
+- `CHANGELOG.md`
+- (verification output only)
 
 **Acceptance criteria:**
 - Verification commands pass.
+- `CHANGELOG.md` updated to reflect the completed work.
 - All tasks marked `Done`.
 - Committed with clear message linked to issue number.
 ```
@@ -222,7 +225,8 @@ git commit -m "{type}(#${issue-number}): task {N} - short description"
 
 1. Run project verification commands (tests/lint/build relevant to the repo).
 2. Write a brief phase summary.
-3. Ensure all completed tasks are committed.
+3. If this is the final cleanup phase, update `CHANGELOG.md` before committing.
+4. Ensure all completed tasks are committed.
 
 ### Task Completion Checklist
 
@@ -230,4 +234,5 @@ Before marking any task Done:
 - [ ] Verification commands pass
 - [ ] Files touched listed in completion note
 - [ ] Key decisions documented
+- [ ] `CHANGELOG.md` updated (final cleanup task)
 - [ ] **Changes committed immediately for this task**

--- a/README.md
+++ b/README.md
@@ -259,8 +259,7 @@ cleanly.
 
 ## Architecture Decision Records
 
-- AD response modernization policy is defined in ADR 0001:
-   `docs/adr/0001-ad-response-modernization.md`.
+- AD response modernization policy is defined in [ADR 0001](docs/adr/0001-ad-response-modernization.md).
 - Use ADR 0001 as the source of truth for compatibility modes, envelope deprecation stages,
    retry/error normalization expectations, and rollout sequencing.
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,13 @@ This project includes a repo skill at `.github/skills/plan-issue/SKILL.md`.
 If a task is large, break it into smaller numbered tasks so each completed task can be committed
 cleanly.
 
+## Architecture Decision Records
+
+- AD response modernization policy is defined in ADR 0001:
+   `docs/adr/0001-ad-response-modernization.md`.
+- Use ADR 0001 as the source of truth for compatibility modes, envelope deprecation stages,
+   retry/error normalization expectations, and rollout sequencing.
+
 ## PR Workflow Skills
 
 This repository also includes PR helper skills:

--- a/docs/adr/0001-ad-response-modernization.md
+++ b/docs/adr/0001-ad-response-modernization.md
@@ -14,6 +14,32 @@ production integrations.
 Issue #16 defines the governance and rollout policy for introducing richer response metadata,
 explicit compatibility modes, and deprecation control without breaking consumers in Stage N.
 
+## Baseline Behavior (Current State)
+
+Current implementation characteristics that this ADR must preserve in Stage N:
+
+- AD connection operations commonly return dictionaries with legacy keys such as `success` and
+	`result`.
+- `ADConnection.get()` currently returns an empty-string `defaultdict` when no result is found,
+	rather than a typed not-found contract.
+- LDAP communication/session failures are retried via reconnect logic in the API layer, including
+	paths that can perform write operations.
+- User batch reads in service layer perform schema validation and can skip invalid records after
+	logging validation errors.
+
+Current release automation constraints:
+
+- Publish workflow derives bump type from merged PR SemVer label (`semver:major`,
+	`semver:minor`, `semver:none`).
+- Exactly one SemVer label is required for release-relevant PRs.
+- `semver:none` explicitly skips version bump and publish.
+
+Known compatibility risks:
+
+- Downstream consumers may rely on legacy `result` payload shape and permissive return patterns.
+- Tightening not-found or validation behavior without compatibility mode can cause regressions.
+- Retry policy changes for write paths may alter observed side effects if not staged carefully.
+
 ## Scope
 
 This ADR defines:

--- a/docs/adr/0001-ad-response-modernization.md
+++ b/docs/adr/0001-ad-response-modernization.md
@@ -19,18 +19,18 @@ explicit compatibility modes, and deprecation control without breaking consumers
 Current implementation characteristics that this ADR must preserve in Stage N:
 
 - AD connection operations commonly return dictionaries with legacy keys such as `success` and
-	`result`.
+  `result`.
 - `ADConnection.get()` currently returns an empty-string `defaultdict` when no result is found,
-	rather than a typed not-found contract.
+  rather than a typed not-found contract.
 - LDAP communication/session failures are retried via reconnect logic in the API layer, including
-	paths that can perform write operations.
+  paths that can perform write operations.
 - User batch reads in service layer perform schema validation and can skip invalid records after
-	logging validation errors.
+  logging validation errors.
 
 Current release automation constraints:
 
 - Publish workflow derives bump type from merged PR SemVer label (`semver:major`,
-	`semver:minor`, `semver:none`).
+  `semver:minor`, `semver:none`).
 - Exactly one SemVer label is required for release-relevant PRs.
 - `semver:none` explicitly skips version bump and publish.
 

--- a/docs/adr/0001-ad-response-modernization.md
+++ b/docs/adr/0001-ad-response-modernization.md
@@ -1,0 +1,90 @@
+# ADR 0001: AD Response Modernization and Compatibility Policy
+
+- Status: Draft
+- Date: 2026-06-08
+- Related issue: #16
+
+## Context
+
+This package is introducing staged modernization for AD-facing APIs and services.
+Downstream systems currently depend on response shapes and behavior that evolved over time,
+including legacy keys and permissive contracts. Moving too quickly risks regressions in
+production integrations.
+
+Issue #16 defines the governance and rollout policy for introducing richer response metadata,
+explicit compatibility modes, and deprecation control without breaking consumers in Stage N.
+
+## Scope
+
+This ADR defines:
+
+- Compatibility mode expectations across rollout stages.
+- Additive-first policy for Stage N.
+- SemVer guardrails for removal of legacy behavior.
+- Required migration guidance for behavior changes.
+- Contract-test expectations for response-shape changes.
+
+## Non-Goals
+
+This ADR does not:
+
+- Implement runtime feature changes directly.
+- Redesign every AD API in one step.
+- Remove legacy behavior in Stage N.
+- Replace issue-level implementation details in follow-up tickets.
+
+## Decision
+
+The project will use staged, compatibility-first modernization:
+
+1. Stage N: additive only; preserve existing behavior contracts.
+2. Stage N+1: default new behavior where approved, while compatibility controls remain.
+3. Stage N+2: allow removals only under explicit semver-major scope with migration support.
+
+## Policy (Initial)
+
+- Public API shape/signature changes must include compatibility behavior and migration guidance.
+- Legacy-compatible behavior removal is forbidden outside explicit semver-major scope.
+- Batch read paths must not silently drop failed records; failure details must be surfaced.
+- When SemVer impact is unclear, stop and clarify before merge/release.
+
+## Consequences
+
+Positive:
+
+- Reduced breakage risk for downstream consumers.
+- Clear migration path and predictable rollout sequencing.
+- Better review discipline for API contract changes.
+
+Trade-offs:
+
+- Additional implementation overhead for compatibility mirroring and documentation.
+- Longer overlap period where old and new behaviors coexist.
+
+## Rollout Stages
+
+- Stage N: additive behavior and compatibility guarantees only.
+- Stage N+1: migration nudges, warnings, and broader adoption of modern contracts.
+- Stage N+2: controlled cleanup for approved semver-major items.
+
+## Migration Guidance Requirements
+
+Any PR that changes public behavior must include:
+
+- Expected SemVer impact and rationale.
+- Before/after usage guidance where relevant.
+- Explicit compatibility note for existing consumers.
+
+## Test and Validation Expectations
+
+For response contract changes, require contract-level tests covering:
+
+- Success and failure response shapes.
+- Compatibility mode behavior where applicable.
+- Not-found and partial-failure semantics where applicable.
+
+## Open Questions
+
+- Final compatibility mode names and defaults for runtime APIs.
+- Standardized error taxonomy naming and granularity.
+- Exact deprecation-warning mechanism and timeline criteria.

--- a/docs/adr/0001-ad-response-modernization.md
+++ b/docs/adr/0001-ad-response-modernization.md
@@ -1,6 +1,6 @@
 # ADR 0001: AD Response Modernization and Compatibility Policy
 
-- Status: Draft
+- Status: Accepted
 - Date: 2026-06-08
 - Related issue: #16
 

--- a/docs/adr/0001-ad-response-modernization.md
+++ b/docs/adr/0001-ad-response-modernization.md
@@ -93,6 +93,104 @@ Trade-offs:
 - Stage N+1: migration nudges, warnings, and broader adoption of modern contracts.
 - Stage N+2: controlled cleanup for approved semver-major items.
 
+## Compatibility Modes
+
+The AD modernization rollout uses three compatibility modes to make behavior explicit while
+preserving safety for existing consumers.
+
+| Mode | Default stage | Contract intent | Required invariants |
+| --- | --- | --- | --- |
+| `legacy` | Stage N default | Preserve pre-modernization behavior by default. | Keep legacy envelope keys (`success`, `result`) available; preserve permissive not-found semantics; avoid raising new contract-level exceptions for existing call paths. |
+| `mixed` | Opt-in during Stage N and broad in Stage N+1 | Return modern envelope fields while mirroring legacy fields. | Include modern metadata and normalized error shape while still emitting legacy mirror keys; behavior must remain non-breaking for consumers reading only legacy keys. |
+| `strict` | Opt-in in Stage N/N+1, candidate default in Stage N+2 | Enforce modern contract without legacy mirrors. | Legacy keys may be omitted; not-found and partial-failure semantics follow modern typed contract; normalized error taxonomy is mandatory. |
+
+Stage N default is `legacy` to guarantee a non-breaking baseline. `mixed` and `strict` are
+adoption tools and must never be forced as the default in Stage N.
+
+## Envelope Deprecation and Mirroring Rules
+
+Envelope modernization follows additive-first rollout and explicit removal gates.
+
+### Envelope shape policy
+
+- Stage N introduces a modern response envelope additively.
+- Stage N and Stage N+1 must mirror legacy keys for compatibility in `legacy` and `mixed`.
+- Mirror fields must represent the same logical outcome as modern fields; divergence is treated
+  as a defect.
+
+### Deprecation timeline
+
+| Stage | Legacy mirror fields | Warnings | Removal eligibility |
+| --- | --- | --- | --- |
+| N | Required | Optional informational guidance only. | Not eligible. |
+| N+1 | Required in `legacy`/`mixed`; optional in `strict`. | Required deprecation warnings when legacy fields are consumed or requested through compatibility controls. | Not eligible for default behavior removals. |
+| N+2 (`semver:major`) | Optional and off by default. | Migration warnings may remain for one major cycle if mirrors are temporarily enabled. | Eligible only when migration guidance, release notes, and compatibility window evidence are complete. |
+
+### Removal gates
+
+Legacy mirror removal requires all of the following:
+
+- PRs are explicitly scoped as breaking and labeled `semver:major`.
+- ADR-linked migration notes provide before/after examples for affected endpoints.
+- Contract tests cover legacy-disabled behavior and assert normalized modern envelope only.
+- Downstream impact assessment is recorded in the issue/PR thread.
+
+## Retry and Error Normalization Policy
+
+Retry behavior and error taxonomy must be consistent across AD API/service boundaries.
+
+### Retry defaults
+
+- Read operations: automatic retry-once after reconnect is allowed by default for transient
+  LDAP/session failures.
+- Write operations: no implicit retry by default to avoid duplicate side effects.
+- Any write-path retry must be explicit, idempotency-justified, and documented in code and PR.
+- Retry overrides must be configurable and default-preserving in Stage N.
+
+### Telemetry requirements
+
+For each retry attempt (or skip decision), emit structured telemetry with at least:
+
+- operation name and read/write classification,
+- attempt count and outcome,
+- error code/category observed,
+- compatibility mode and envelope mode context.
+
+Telemetry data must allow distinguishing transient transport failures from deterministic
+validation or authorization failures.
+
+### Normalized error taxonomy
+
+Modern responses should provide normalized machine-routable error codes. Initial required
+categories are:
+
+- `not_found`
+- `validation_error`
+- `auth_error`
+- `permission_denied`
+- `connection_error`
+- `timeout`
+- `conflict`
+- `unknown_error`
+
+Unknown or unmapped failures must resolve to `unknown_error` while preserving diagnostic context
+in logs/metadata. Consumers must be able to route based on normalized code without parsing human
+message text.
+
+## Rollout Stage to Issue Mapping
+
+The following issues define implementation sequencing for this ADR.
+
+| Stage | Goal | Issues | Dependency notes |
+| --- | --- | --- | --- |
+| Stage N (additive, non-breaking baseline) | Establish compatibility controls and modern envelope primitives while preserving legacy behavior. | #17 global compatibility modes; #18 typed response models with dict-compatible adapters; #19 operation envelope with legacy mirroring; #20 normalized error taxonomy utilities; #21 retry metadata and policy telemetry. | Sequence: #17 -> #18 -> #19. Then #20 and #21 build on envelope and mode context from #17/#19. |
+| Stage N+1 (adoption and expansion) | Expand modern APIs and migration tooling while keeping compatibility controls available. | #22 membership APIs v2 (direct groups/primary group); #23 membership APIs v2 (transitive groups/members paging); #24 batch read v2 partial-failure contract; #25 multivalue dual-form support; #26 explicit get_v2 typed not-found contract; #27 in-package discoverability toolkit. | #22 should precede #23 for membership layering. #24/#25/#26 depend on Stage N envelope and error primitives. #27 should follow early N+1 implementations to document finalized usage. |
+| Stage N+2 (major cleanup) | Remove legacy mirrors and legacy get semantics under explicit breaking scope. | #28 [MAJOR] remove legacy mirrored keys and legacy get semantics. | Requires Stage N and N+1 migration signals, published guidance, and explicit `semver:major` release intent. |
+| Cross-stage governance (supports all stages) | Enforce release and plan protocol discipline during rollout. | #29 PR-time SemVer label validation; #30 PR template SemVer checklist; #31 harden plan-issue discoverability; #32 enforce commit-after-each-task policy. | Can run in parallel with implementation stages; should land before broad N+1 rollout to reduce process drift. |
+
+This mapping is sequencing guidance, not a hard gate matrix. If scope changes, update this ADR and
+the linked issue set in the same PR.
+
 ## Migration Guidance Requirements
 
 Any PR that changes public behavior must include:


### PR DESCRIPTION
## Description
Define and finalize ADR 0001 for AD response modernization rollout and compatibility policy, then align contributor/agent docs and planning workflow behavior.

This consolidates Issue #16 execution across setup, core policy, adoption, and cleanup deliverables.

## Changes
- Added and completed ADR 0001 policy sections in `docs/adr/0001-ad-response-modernization.md`:
  - Compatibility modes (`legacy`, `mixed`, `strict`)
  - Envelope deprecation/mirroring timeline and removal gates
  - Retry defaults, telemetry requirements, and normalized error taxonomy
  - Stage mapping from rollout phases to issues `#17`-`#32` with dependency notes
- Added ADR discoverability documentation:
  - `README.md` (`Architecture Decision Records` section)
  - `.github/copilot-instructions.md` (explicit ADR 0001 policy pointer)
- Updated plan execution skill to enforce end-of-plan changelog hygiene:
  - `.github/skills/plan-issue/SKILL.md`
  - Cleanup phase now requires `CHANGELOG.md` update check before final commit

## Testing
- Verified markdown diagnostics are clean for:
  - `docs/adr/0001-ad-response-modernization.md`
  - `README.md`
  - `.github/copilot-instructions.md`
- Confirmed git history and branch synchronization against `origin/main`

SemVer intent: `semver:none`

Closes #16