### PR TITLE
feat(#17): add AD compatibility mode controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - 8 new unit tests for reconnect behaviour (64 total tests)
 - Repository planning and PR workflow skills: `plan-issue`, `pr-create`, and `pr-comments`
 - PR template and contributor guidance for SemVer labeling and task-bounded commit workflow
+- AD compatibility mode framework with `legacy`, `mixed`, and `strict` modes, including:
+  global/env resolution (`PYTHON_APIS_AD_COMPAT_MODE`), service defaults, per-call overrides,
+  and runtime introspection helpers for AD services and ADConnection
+- Expanded compatibility-mode coverage across AD API and service tests
 
 ### Fixed
 

--- a/src/python_apis/apis/__init__.py
+++ b/src/python_apis/apis/__init__.py
@@ -38,12 +38,22 @@ Dependencies:
 
 """
 
-from python_apis.apis.ad_api import ADConnection
+from python_apis.apis.ad_api import (
+    ADConnection,
+    AD_COMPATIBILITY_ENV_VAR,
+    AD_COMPATIBILITY_MODES,
+    AD_DEFAULT_COMPATIBILITY_MODE,
+    resolve_ad_compatibility_mode,
+)
 from python_apis.apis.jira_api import JiraConnection
 from python_apis.apis.sql_api import SQLConnection
 
 __all__ = [
     "ADConnection",
+    "AD_COMPATIBILITY_ENV_VAR",
+    "AD_COMPATIBILITY_MODES",
+    "AD_DEFAULT_COMPATIBILITY_MODE",
+    "resolve_ad_compatibility_mode",
     "JiraConnection",
     "SQLConnection",
 ]

--- a/src/python_apis/apis/ad_api.py
+++ b/src/python_apis/apis/ad_api.py
@@ -101,11 +101,18 @@ class ADConnection:
         - Invalid or empty mode values always resolve to ``legacy``.
     """
 
-    def __init__(self, servers: list, search_base: str, enable_ldap_logging: bool = False):
+    def __init__(
+        self,
+        servers: list,
+        search_base: str,
+        enable_ldap_logging: bool = False,
+        compatibility_mode: str | None = None,
+    ):
         if enable_ldap_logging:
             set_library_log_detail_level(BASIC)
 
         self._servers = servers
+        self.compatibility_mode = resolve_ad_compatibility_mode(service_mode=compatibility_mode)
         self.connection = self._get_connection(servers)
         self.search_base = search_base
 

--- a/src/python_apis/apis/ad_api.py
+++ b/src/python_apis/apis/ad_api.py
@@ -10,6 +10,7 @@ AD to run it effectively.
 import collections
 import functools
 import logging
+import os
 import ssl
 from typing import Any
 
@@ -22,6 +23,44 @@ from ldap3.core.exceptions import LDAPCommunicationError, LDAPSessionTerminatedB
 logger = logging.getLogger(__name__)
 
 _RECOVERABLE_EXCEPTIONS = (LDAPSessionTerminatedByServerError, LDAPCommunicationError)
+
+AD_COMPATIBILITY_MODES = ('legacy', 'mixed', 'strict')
+AD_DEFAULT_COMPATIBILITY_MODE = 'legacy'
+AD_COMPATIBILITY_ENV_VAR = 'PYTHON_APIS_AD_COMPAT_MODE'
+
+
+def resolve_ad_compatibility_mode(
+    per_call_mode: str | None = None,
+    service_mode: str | None = None,
+    env_mode: str | None = None,
+) -> str:
+    """Resolve the effective AD compatibility mode.
+
+    Precedence is deterministic and shared across AD APIs/services:
+    `per_call_mode` -> `service_mode` -> environment variable
+    (`PYTHON_APIS_AD_COMPAT_MODE`) -> `legacy`.
+
+    Any unknown, empty, or whitespace-only mode value falls back to `legacy`.
+    """
+
+    selected_env_mode = env_mode if env_mode is not None else os.getenv(AD_COMPATIBILITY_ENV_VAR)
+    candidates = (per_call_mode, service_mode, selected_env_mode)
+    for mode in candidates:
+        if mode is None:
+            continue
+        normalized_mode = str(mode).strip().lower()
+        if not normalized_mode:
+            continue
+        if normalized_mode in AD_COMPATIBILITY_MODES:
+            return normalized_mode
+        logger.warning(
+            "Unsupported AD compatibility mode '%s'. Falling back to '%s'.",
+            mode,
+            AD_DEFAULT_COMPATIBILITY_MODE,
+        )
+        return AD_DEFAULT_COMPATIBILITY_MODE
+
+    return AD_DEFAULT_COMPATIBILITY_MODE
 
 
 def _auto_reconnect(method):
@@ -54,6 +93,12 @@ class ADMissingServersError(Exception):
 class ADConnection:
     """This class contains the functionality concerning the
     connection and the methods that gets data from AD and can modify the AD.
+
+        Compatibility mode contract (Stage N):
+        - Supported modes: ``legacy``, ``mixed``, ``strict``.
+        - Mode precedence: per-call override, then service default, then environment
+            default, and finally ``legacy`` fallback.
+        - Invalid or empty mode values always resolve to ``legacy``.
     """
 
     def __init__(self, servers: list, search_base: str, enable_ldap_logging: bool = False):

--- a/src/python_apis/services/__init__.py
+++ b/src/python_apis/services/__init__.py
@@ -9,11 +9,23 @@ module or a few of them.
 from python_apis.services.ad_group_service import ADGroupService
 from python_apis.services.ad_user_service import ADUserService
 from python_apis.services.ad_ou_service import ADOrganizationalUnitService
+from python_apis.services.compatibility_mode import (
+    ADCompatibilityMode,
+    AD_COMPATIBILITY_ENV_VAR,
+    AD_COMPATIBILITY_MODES,
+    AD_DEFAULT_COMPATIBILITY_MODE,
+    resolve_service_compatibility_mode,
+)
 from python_apis.services.employee_service import EmployeeService
 
 __all__ = [
     "ADGroupService",
     "ADUserService",
     "ADOrganizationalUnitService",
+    "ADCompatibilityMode",
+    "AD_COMPATIBILITY_ENV_VAR",
+    "AD_COMPATIBILITY_MODES",
+    "AD_DEFAULT_COMPATIBILITY_MODE",
+    "resolve_service_compatibility_mode",
     "EmployeeService",
 ]

--- a/src/python_apis/services/ad_group_service.py
+++ b/src/python_apis/services/ad_group_service.py
@@ -18,6 +18,12 @@ from python_apis.schemas import ADGroupSchema
 
 class ADGroupService:
     """Service class for interacting with Active Directory groups.
+
+        Compatibility mode contract:
+        - Supported modes are ``legacy``, ``mixed``, and ``strict``.
+        - Effective mode precedence is per-call override, then service default,
+            then `PYTHON_APIS_AD_COMPAT_MODE`, then ``legacy`` fallback.
+        - Invalid or empty mode values must resolve to ``legacy`` deterministically.
     """
 
     def __init__(self, ad_connection: ADConnection = None, sql_connection: SQLConnection = None,

--- a/src/python_apis/services/ad_group_service.py
+++ b/src/python_apis/services/ad_group_service.py
@@ -59,6 +59,13 @@ class ADGroupService:
             ad_connection = self._get_ad_connection(ldap_logging)
         self.ad_connection = ad_connection
 
+    def _resolve_effective_mode(self, compatibility_mode: str | None = None) -> str:
+        """Resolve effective compatibility mode for a service operation."""
+        return resolve_service_compatibility_mode(
+            per_call_mode=compatibility_mode,
+            service_mode=self.compatibility_mode,
+        )
+
     def _get_sql_connection(self) -> SQLConnection:
         """Create and return a SQLConnection instance based on environment variables.
 
@@ -139,8 +146,11 @@ class ADGroupService:
             self.logger.error('Rolling back changes, error: %s', e)
             raise e
 
-    def get_groups_from_ad(self, search_filter: str = '(objectClass=group)'
-                           ) -> list[ADGroup]:
+    def get_groups_from_ad(
+        self,
+        search_filter: str = '(objectClass=group)',
+        compatibility_mode: str | None = None,
+    ) -> list[ADGroup]:
         """Retrieve groups from Active Directory based on a search filter.
 
         Args:
@@ -149,6 +159,9 @@ class ADGroupService:
         Returns:
             list[ADGroup]: A list of ADGroup instances matching the search criteria.
         """
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
+        self.logger.debug("Using AD compatibility mode '%s' for get_groups_from_ad", effective_mode)
+
         attributes = ADGroup.get_attribute_list()
         ad_groups_dict = self.ad_connection.search(search_filter, attributes)
         ad_groups = []

--- a/src/python_apis/services/ad_group_service.py
+++ b/src/python_apis/services/ad_group_service.py
@@ -66,6 +66,14 @@ class ADGroupService:
             service_mode=self.compatibility_mode,
         )
 
+    def get_compatibility_mode(self, compatibility_mode: str | None = None) -> dict[str, str]:
+        """Return service default and effective compatibility mode for this context."""
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
+        return {
+            'service_default_mode': self.compatibility_mode,
+            'effective_mode': effective_mode,
+        }
+
     def _get_sql_connection(self) -> SQLConnection:
         """Create and return a SQLConnection instance based on environment variables.
 

--- a/src/python_apis/services/ad_group_service.py
+++ b/src/python_apis/services/ad_group_service.py
@@ -15,6 +15,7 @@ from dev_tools import timing_decorator
 from python_apis.apis import ADConnection, SQLConnection
 from python_apis.models import ADGroup, base
 from python_apis.schemas import ADGroupSchema
+from python_apis.services.compatibility_mode import resolve_service_compatibility_mode
 
 class ADGroupService:
     """Service class for interacting with Active Directory groups.
@@ -26,8 +27,13 @@ class ADGroupService:
         - Invalid or empty mode values must resolve to ``legacy`` deterministically.
     """
 
-    def __init__(self, ad_connection: ADConnection = None, sql_connection: SQLConnection = None,
-                 ldap_logging: bool = False):
+    def __init__(
+        self,
+        ad_connection: ADConnection = None,
+        sql_connection: SQLConnection = None,
+        ldap_logging: bool = False,
+        compatibility_mode: str | None = None,
+    ):
         """Initialize the ADGroupService with an ADConnection and a db connection.
 
         Args:
@@ -36,8 +42,14 @@ class ADGroupService:
             sql_connection (SQLConnection, optional): An existing SQLConnection instance.
                 If None, a new one will be created.
             ldap_logging (bool, optional): Whether to enable LDAP logging. Defaults to False.
+            compatibility_mode (str | None, optional): Default compatibility mode for the
+                service instance. Resolved with deterministic precedence against environment
+                defaults and fallback behavior.
         """
         self.logger = getLogger(__name__)
+        self.compatibility_mode = resolve_service_compatibility_mode(
+            service_mode=compatibility_mode
+        )
 
         if sql_connection is None:
             sql_connection = self._get_sql_connection()

--- a/src/python_apis/services/ad_ou_service.py
+++ b/src/python_apis/services/ad_ou_service.py
@@ -67,6 +67,14 @@ class ADOrganizationalUnitService:
             service_mode=self.compatibility_mode,
         )
 
+    def get_compatibility_mode(self, compatibility_mode: str | None = None) -> dict[str, str]:
+        """Return service default and effective compatibility mode for this context."""
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
+        return {
+            'service_default_mode': self.compatibility_mode,
+            'effective_mode': effective_mode,
+        }
+
     def _get_sql_connection(self) -> SQLConnection:
         """Create and return a SQLConnection instance based on environment variables.
 

--- a/src/python_apis/services/ad_ou_service.py
+++ b/src/python_apis/services/ad_ou_service.py
@@ -16,6 +16,7 @@ from dev_tools import timing_decorator
 from python_apis.apis import ADConnection, SQLConnection
 from python_apis.models import ADOrganizationalUnit, base
 from python_apis.schemas import ADOrganizationalUnitSchema
+from python_apis.services.compatibility_mode import resolve_service_compatibility_mode
 
 class ADOrganizationalUnitService:
     """Service class for interacting with Active Directory organizational units.
@@ -27,8 +28,13 @@ class ADOrganizationalUnitService:
         - Invalid or empty mode values must resolve to ``legacy`` deterministically.
     """
 
-    def __init__(self, ad_connection: ADConnection = None, sql_connection: SQLConnection = None,
-                 ldap_logging: bool = False):
+    def __init__(
+        self,
+        ad_connection: ADConnection = None,
+        sql_connection: SQLConnection = None,
+        ldap_logging: bool = False,
+        compatibility_mode: str | None = None,
+    ):
         """Initialize the ADOrganizationalUnitService with an ADConnection and a db connection.
 
         Args:
@@ -37,8 +43,14 @@ class ADOrganizationalUnitService:
             sql_connection (SQLConnection, optional): An existing SQLConnection instance.
                 If None, a new one will be created.
             ldap_logging (bool, optional): Whether to enable LDAP logging. Defaults to False.
+            compatibility_mode (str | None, optional): Default compatibility mode for the
+                service instance. Resolved with deterministic precedence against environment
+                defaults and fallback behavior.
         """
         self.logger = getLogger(__name__)
+        self.compatibility_mode = resolve_service_compatibility_mode(
+            service_mode=compatibility_mode
+        )
 
         if sql_connection is None:
             sql_connection = self._get_sql_connection()

--- a/src/python_apis/services/ad_ou_service.py
+++ b/src/python_apis/services/ad_ou_service.py
@@ -19,6 +19,12 @@ from python_apis.schemas import ADOrganizationalUnitSchema
 
 class ADOrganizationalUnitService:
     """Service class for interacting with Active Directory organizational units.
+
+        Compatibility mode contract:
+        - Supported modes are ``legacy``, ``mixed``, and ``strict``.
+        - Effective mode precedence is per-call override, then service default,
+            then `PYTHON_APIS_AD_COMPAT_MODE`, then ``legacy`` fallback.
+        - Invalid or empty mode values must resolve to ``legacy`` deterministically.
     """
 
     def __init__(self, ad_connection: ADConnection = None, sql_connection: SQLConnection = None,

--- a/src/python_apis/services/ad_ou_service.py
+++ b/src/python_apis/services/ad_ou_service.py
@@ -60,6 +60,13 @@ class ADOrganizationalUnitService:
             ad_connection = self._get_ad_connection(ldap_logging)
         self.ad_connection = ad_connection
 
+    def _resolve_effective_mode(self, compatibility_mode: str | None = None) -> str:
+        """Resolve effective compatibility mode for a service operation."""
+        return resolve_service_compatibility_mode(
+            per_call_mode=compatibility_mode,
+            service_mode=self.compatibility_mode,
+        )
+
     def _get_sql_connection(self) -> SQLConnection:
         """Create and return a SQLConnection instance based on environment variables.
 
@@ -190,8 +197,11 @@ class ADOrganizationalUnitService:
             self.logger.error('Rolling back changes, error: %s', e)
             raise e
 
-    def get_ous_from_ad(self, search_filter: str = '(objectClass=organizationalUnit)'
-                        ) -> list[ADOrganizationalUnit]:
+    def get_ous_from_ad(
+        self,
+        search_filter: str = '(objectClass=organizationalUnit)',
+        compatibility_mode: str | None = None,
+    ) -> list[ADOrganizationalUnit]:
         """Retrieve organizational units from Active Directory based on a search filter.
 
         Args:
@@ -201,6 +211,9 @@ class ADOrganizationalUnitService:
             list[ADOrganizationalUnit]: A list of ADOrganizationalUnit instances matching the
             search criteria.
         """
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
+        self.logger.debug("Using AD compatibility mode '%s' for get_ous_from_ad", effective_mode)
+
         attributes = ADOrganizationalUnit.get_attribute_list()
         ad_ous_dict = self.ad_connection.search(search_filter, attributes)
         ad_ous = []

--- a/src/python_apis/services/ad_user_service.py
+++ b/src/python_apis/services/ad_user_service.py
@@ -18,6 +18,12 @@ from python_apis.schemas import ADUserSchema
 
 class ADUserService:
     """Service class for interacting with Active Directory users.
+
+        Compatibility mode contract:
+        - Supported modes are ``legacy``, ``mixed``, and ``strict``.
+        - Effective mode precedence is per-call override, then service default,
+            then `PYTHON_APIS_AD_COMPAT_MODE`, then ``legacy`` fallback.
+        - Invalid or empty mode values must resolve to ``legacy`` deterministically.
     """
 
     def __init__(self, ad_connection: ADConnection = None, sql_connection: SQLConnection = None,

--- a/src/python_apis/services/ad_user_service.py
+++ b/src/python_apis/services/ad_user_service.py
@@ -66,6 +66,14 @@ class ADUserService:
             service_mode=self.compatibility_mode,
         )
 
+    def get_compatibility_mode(self, compatibility_mode: str | None = None) -> dict[str, str]:
+        """Return service default and effective compatibility mode for this context."""
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
+        return {
+            'service_default_mode': self.compatibility_mode,
+            'effective_mode': effective_mode,
+        }
+
     def _get_sql_connection(self) -> SQLConnection:
         return SQLConnection(
             server=os.getenv('AD_DB_SERVER', os.getenv('DEFAULT_DB_SERVER')),

--- a/src/python_apis/services/ad_user_service.py
+++ b/src/python_apis/services/ad_user_service.py
@@ -59,6 +59,13 @@ class ADUserService:
             ad_connection = self._get_ad_connection(ldap_logging)
         self.ad_connection = ad_connection
 
+    def _resolve_effective_mode(self, compatibility_mode: str | None = None) -> str:
+        """Resolve effective compatibility mode for a service operation."""
+        return resolve_service_compatibility_mode(
+            per_call_mode=compatibility_mode,
+            service_mode=self.compatibility_mode,
+        )
+
     def _get_sql_connection(self) -> SQLConnection:
         return SQLConnection(
             server=os.getenv('AD_DB_SERVER', os.getenv('DEFAULT_DB_SERVER')),
@@ -128,7 +135,11 @@ class ADUserService:
             self.logger.error('Rolling back changes, error: %s', e)
             raise e
 
-    def get_users_from_ad(self, search_filter: str = '(objectClass=user)') -> list[ADUser]:
+    def get_users_from_ad(
+        self,
+        search_filter: str = '(objectClass=user)',
+        compatibility_mode: str | None = None,
+    ) -> list[ADUser]:
         """Retrieve users from Active Directory based on a search filter.
 
         Args:
@@ -137,6 +148,9 @@ class ADUserService:
         Returns:
             list[ADUser]: A list of ADUser instances matching the search criteria.
         """
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
+        self.logger.debug("Using AD compatibility mode '%s' for get_users_from_ad", effective_mode)
+
         attributes = ADUser.get_attribute_list()
         ad_users_dict = self.ad_connection.search(search_filter, attributes)
         ad_users = []
@@ -159,12 +173,22 @@ class ADUserService:
         #ad_users = [ADUser(**x) for x in ad_users_dict]
         return ad_users
 
-    def get_all_sam_account_names(self, search_filter: str = '(objectClass=user)') -> set[str]:
+    def get_all_sam_account_names(
+        self,
+        search_filter: str = '(objectClass=user)',
+        compatibility_mode: str | None = None,
+    ) -> set[str]:
         """Retrieve all sAMAccountName values from Active Directory.
 
         Returns:
             set[str]: A set of all sAMAccountName values.
         """
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
+        self.logger.debug(
+            "Using AD compatibility mode '%s' for get_all_sam_account_names",
+            effective_mode,
+        )
+
         attributes = ['sAMAccountName']
         ad_users_dict = self.ad_connection.search(search_filter, attributes)
         sam_account_names = {str(user.get('sAMAccountName')) for user

--- a/src/python_apis/services/ad_user_service.py
+++ b/src/python_apis/services/ad_user_service.py
@@ -15,6 +15,7 @@ from dev_tools import timing_decorator
 from python_apis.apis import ADConnection, SQLConnection
 from python_apis.models import ADUser
 from python_apis.schemas import ADUserSchema
+from python_apis.services.compatibility_mode import resolve_service_compatibility_mode
 
 class ADUserService:
     """Service class for interacting with Active Directory users.
@@ -26,8 +27,13 @@ class ADUserService:
         - Invalid or empty mode values must resolve to ``legacy`` deterministically.
     """
 
-    def __init__(self, ad_connection: ADConnection = None, sql_connection: SQLConnection = None,
-                 ldap_logging: bool = False):
+    def __init__(
+        self,
+        ad_connection: ADConnection = None,
+        sql_connection: SQLConnection = None,
+        ldap_logging: bool = False,
+        compatibility_mode: str | None = None,
+    ):
         """Initialize the ADUserService with an ADConnection and an SQLConnection.
 
         Args:
@@ -36,8 +42,14 @@ class ADUserService:
             sql_connection (SQLConnection, optional): An existing SQLConnection instance.
                 If None, a new one will be created.
             ldap_logging (bool, optional): Whether to enable LDAP logging. Defaults to False.
+            compatibility_mode (str | None, optional): Default compatibility mode for the
+                service instance. Resolved with deterministic precedence against environment
+                defaults and fallback behavior.
         """
         self.logger = getLogger(__name__)
+        self.compatibility_mode = resolve_service_compatibility_mode(
+            service_mode=compatibility_mode
+        )
 
         if sql_connection is None:
             sql_connection = self._get_sql_connection()

--- a/src/python_apis/services/compatibility_mode.py
+++ b/src/python_apis/services/compatibility_mode.py
@@ -1,0 +1,46 @@
+"""Utilities for resolving AD compatibility mode in service layer code.
+
+This module centralizes mode resolution for AD services while reusing the
+contract defined in ``python_apis.apis.ad_api``.
+"""
+
+from typing import Literal, cast
+
+from python_apis.apis.ad_api import (
+    AD_COMPATIBILITY_ENV_VAR,
+    AD_COMPATIBILITY_MODES,
+    AD_DEFAULT_COMPATIBILITY_MODE,
+    resolve_ad_compatibility_mode,
+)
+
+ADCompatibilityMode = Literal["legacy", "mixed", "strict"]
+
+
+def resolve_service_compatibility_mode(
+    per_call_mode: str | None = None,
+    service_mode: str | None = None,
+    env_mode: str | None = None,
+) -> ADCompatibilityMode:
+    """Resolve effective AD compatibility mode for service-layer operations.
+
+    Precedence is ``per_call_mode`` -> ``service_mode`` -> environment
+    (``PYTHON_APIS_AD_COMPAT_MODE``) -> ``legacy`` fallback.
+    """
+
+    return cast(
+        ADCompatibilityMode,
+        resolve_ad_compatibility_mode(
+            per_call_mode=per_call_mode,
+            service_mode=service_mode,
+            env_mode=env_mode,
+        ),
+    )
+
+
+__all__ = [
+    "ADCompatibilityMode",
+    "AD_COMPATIBILITY_MODES",
+    "AD_DEFAULT_COMPATIBILITY_MODE",
+    "AD_COMPATIBILITY_ENV_VAR",
+    "resolve_service_compatibility_mode",
+]

--- a/src/tests/test_apis/test_ad_api.py
+++ b/src/tests/test_apis/test_ad_api.py
@@ -1,10 +1,16 @@
 # test_ad_api.py
 import unittest
 from unittest.mock import patch, MagicMock
+import os
 import ssl
-from ldap3 import MODIFY_ADD, MODIFY_DELETE, MODIFY_REPLACE, ALL_ATTRIBUTES, SUBTREE, SASL, GSSAPI
+from ldap3 import MODIFY_ADD, MODIFY_DELETE, MODIFY_REPLACE
 from ldap3.core.exceptions import LDAPCommunicationError, LDAPSessionTerminatedByServerError
-from python_apis.apis.ad_api import ADConnection, ADConnectionError, ADMissingServersError
+from python_apis.apis.ad_api import (
+    ADConnection,
+    ADConnectionError,
+    ADMissingServersError,
+    resolve_ad_compatibility_mode,
+)
 
 
 class TestADConnection(unittest.TestCase):
@@ -42,7 +48,7 @@ class TestADConnection(unittest.TestCase):
     def test_get_ad_connection(self, mock_server_cls, mock_server_pool_cls):
         mock_tls_obj = MagicMock()
         with patch('python_apis.apis.ad_api.Tls', return_value=mock_tls_obj) as mock_tls:
-            ad_conn = ADConnection(self.servers, self.search_base)
+            ADConnection(self.servers, self.search_base)
 
         mock_tls.assert_called_once_with(validate=ssl.CERT_NONE, version=ssl.PROTOCOL_TLSv1_2)
         self.assertEqual(mock_server_cls.call_count, len(self.servers))
@@ -204,7 +210,7 @@ class TestAutoReconnect(unittest.TestCase):
         ad_conn.rebind()
 
         self.assertIsNot(ad_conn.connection, old_connection)
-        old_connection.unbind.assert_called_once()
+        self.mock_connection.unbind.assert_called_once()
 
     def test_rebind_still_works_when_unbind_raises_session_terminated(self):
         ad_conn = ADConnection(self.servers, self.search_base)
@@ -289,6 +295,55 @@ class TestAutoReconnect(unittest.TestCase):
 
         with self.assertRaises(ADConnectionError):
             ad_conn.rebind()
+
+
+class TestCompatibilityModeResolution(unittest.TestCase):
+    """Tests for compatibility mode resolution precedence and fallback."""
+
+    def setUp(self):
+        self.env_var = 'PYTHON_APIS_AD_COMPAT_MODE'
+        self.original_env = os.environ.get(self.env_var)
+
+    def tearDown(self):
+        env = os.environ
+        if self.original_env is None:
+            env.pop(self.env_var, None)
+            return
+        env[self.env_var] = self.original_env
+
+    def test_per_call_mode_has_highest_precedence(self):
+        os.environ[self.env_var] = 'strict'
+
+        result = resolve_ad_compatibility_mode(
+            per_call_mode='mixed',
+            service_mode='legacy',
+        )
+
+        self.assertEqual(result, 'mixed')
+
+    def test_service_mode_used_when_per_call_missing(self):
+        os.environ[self.env_var] = 'strict'
+
+        result = resolve_ad_compatibility_mode(service_mode='mixed')
+
+        self.assertEqual(result, 'mixed')
+
+    def test_environment_mode_used_when_no_explicit_modes(self):
+        os.environ[self.env_var] = 'strict'
+
+        result = resolve_ad_compatibility_mode()
+
+        self.assertEqual(result, 'strict')
+
+    def test_legacy_fallback_for_invalid_mode(self):
+        result = resolve_ad_compatibility_mode(per_call_mode='invalid')
+
+        self.assertEqual(result, 'legacy')
+
+    def test_mode_values_are_normalized(self):
+        result = resolve_ad_compatibility_mode(per_call_mode='  MiXeD  ')
+
+        self.assertEqual(result, 'mixed')
 
 
 if __name__ == '__main__':

--- a/src/tests/test_apis/test_ad_api.py
+++ b/src/tests/test_apis/test_ad_api.py
@@ -30,6 +30,12 @@ class TestADConnection(unittest.TestCase):
         conn = ADConnection(self.servers, self.search_base)
         self.assertEqual(conn.search_base, self.search_base)
         self.assertIsNotNone(conn.connection)
+        self.assertEqual(conn.compatibility_mode, 'legacy')
+
+    def test_init_with_explicit_compatibility_mode(self):
+        conn = ADConnection(self.servers, self.search_base, compatibility_mode='strict')
+
+        self.assertEqual(conn.compatibility_mode, 'strict')
 
     def test_init_no_servers_raises_exception(self):
         with self.assertRaises(ADMissingServersError):

--- a/src/tests/test_apis/test_ad_api.py
+++ b/src/tests/test_apis/test_ad_api.py
@@ -7,6 +7,7 @@ from ldap3 import MODIFY_ADD, MODIFY_DELETE, MODIFY_REPLACE
 from ldap3.core.exceptions import LDAPCommunicationError, LDAPSessionTerminatedByServerError
 from python_apis.apis.ad_api import (
     ADConnection,
+    AD_COMPATIBILITY_ENV_VAR,
     ADConnectionError,
     ADMissingServersError,
     resolve_ad_compatibility_mode,
@@ -307,7 +308,7 @@ class TestCompatibilityModeResolution(unittest.TestCase):
     """Tests for compatibility mode resolution precedence and fallback."""
 
     def setUp(self):
-        self.env_var = 'PYTHON_APIS_AD_COMPAT_MODE'
+        self.env_var = AD_COMPATIBILITY_ENV_VAR
         self.original_env = os.environ.get(self.env_var)
 
     def tearDown(self):

--- a/src/tests/test_services/test_ad_service_compatibility_mode.py
+++ b/src/tests/test_services/test_ad_service_compatibility_mode.py
@@ -146,6 +146,48 @@ class TestServiceCompatibilityModeDefaults(unittest.TestCase):
 
         mock_resolve.assert_called_with(per_call_mode="mixed", service_mode="legacy")
 
+    def test_user_introspection_returns_default_and_effective_modes(self):
+        service = ADUserService(
+            ad_connection=self.mock_ad_connection,
+            sql_connection=self.mock_sql_connection,
+            compatibility_mode="legacy",
+        )
+
+        introspection = service.get_compatibility_mode(compatibility_mode="strict")
+
+        self.assertEqual(
+            introspection,
+            {"service_default_mode": "legacy", "effective_mode": "strict"},
+        )
+
+    def test_group_introspection_without_per_call_uses_service_default(self):
+        service = ADGroupService(
+            ad_connection=self.mock_ad_connection,
+            sql_connection=self.mock_sql_connection,
+            compatibility_mode="mixed",
+        )
+
+        introspection = service.get_compatibility_mode()
+
+        self.assertEqual(
+            introspection,
+            {"service_default_mode": "mixed", "effective_mode": "mixed"},
+        )
+
+    def test_ou_introspection_with_invalid_per_call_falls_back_to_legacy(self):
+        service = ADOrganizationalUnitService(
+            ad_connection=self.mock_ad_connection,
+            sql_connection=self.mock_sql_connection,
+            compatibility_mode="strict",
+        )
+
+        introspection = service.get_compatibility_mode(compatibility_mode="bad")
+
+        self.assertEqual(
+            introspection,
+            {"service_default_mode": "strict", "effective_mode": "legacy"},
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/tests/test_services/test_ad_service_compatibility_mode.py
+++ b/src/tests/test_services/test_ad_service_compatibility_mode.py
@@ -19,9 +19,13 @@ class TestServiceCompatibilityModeDefaults(unittest.TestCase):
     def setUp(self):
         self.mock_ad_connection = MagicMock()
         self.mock_sql_connection = MagicMock()
+        self.original_env_value = os.environ.get(AD_COMPATIBILITY_ENV_VAR)
 
     def tearDown(self):
-        os.environ.pop(AD_COMPATIBILITY_ENV_VAR, None)
+        if self.original_env_value is None:
+            os.environ.pop(AD_COMPATIBILITY_ENV_VAR, None)
+            return
+        os.environ[AD_COMPATIBILITY_ENV_VAR] = self.original_env_value
 
     def test_user_service_defaults_to_legacy(self):
         service = ADUserService(

--- a/src/tests/test_services/test_ad_service_compatibility_mode.py
+++ b/src/tests/test_services/test_ad_service_compatibility_mode.py
@@ -2,7 +2,7 @@
 
 import os
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from python_apis.services import (
     ADGroupService,
@@ -10,6 +10,7 @@ from python_apis.services import (
     ADUserService,
 )
 from python_apis.services.compatibility_mode import AD_COMPATIBILITY_ENV_VAR
+from python_apis.services.compatibility_mode import resolve_service_compatibility_mode
 
 
 class TestServiceCompatibilityModeDefaults(unittest.TestCase):
@@ -57,6 +58,93 @@ class TestServiceCompatibilityModeDefaults(unittest.TestCase):
         )
 
         self.assertEqual(service.compatibility_mode, "legacy")
+
+    def test_service_supports_all_explicit_modes(self):
+        for mode in ("legacy", "mixed", "strict"):
+            with self.subTest(mode=mode):
+                user_service = ADUserService(
+                    ad_connection=self.mock_ad_connection,
+                    sql_connection=self.mock_sql_connection,
+                    compatibility_mode=mode,
+                )
+                group_service = ADGroupService(
+                    ad_connection=self.mock_ad_connection,
+                    sql_connection=self.mock_sql_connection,
+                    compatibility_mode=mode,
+                )
+                ou_service = ADOrganizationalUnitService(
+                    ad_connection=self.mock_ad_connection,
+                    sql_connection=self.mock_sql_connection,
+                    compatibility_mode=mode,
+                )
+
+                self.assertEqual(user_service.compatibility_mode, mode)
+                self.assertEqual(group_service.compatibility_mode, mode)
+                self.assertEqual(ou_service.compatibility_mode, mode)
+
+    def test_per_call_override_precedence_helper(self):
+        os.environ[AD_COMPATIBILITY_ENV_VAR] = "strict"
+
+        service = ADUserService(
+            ad_connection=self.mock_ad_connection,
+            sql_connection=self.mock_sql_connection,
+            compatibility_mode="legacy",
+        )
+
+        effective_mode = resolve_service_compatibility_mode(
+            per_call_mode="mixed",
+            service_mode=service.compatibility_mode,
+        )
+
+        self.assertEqual(effective_mode, "mixed")
+
+    def test_user_read_operation_accepts_per_call_override(self):
+        service = ADUserService(
+            ad_connection=self.mock_ad_connection,
+            sql_connection=self.mock_sql_connection,
+            compatibility_mode="legacy",
+        )
+        self.mock_ad_connection.search.return_value = []
+
+        with patch(
+            "python_apis.services.ad_user_service.resolve_service_compatibility_mode",
+            return_value="mixed",
+        ) as mock_resolve:
+            service.get_users_from_ad(compatibility_mode="mixed")
+
+        mock_resolve.assert_called_with(per_call_mode="mixed", service_mode="legacy")
+
+    def test_group_read_operation_accepts_per_call_override(self):
+        service = ADGroupService(
+            ad_connection=self.mock_ad_connection,
+            sql_connection=self.mock_sql_connection,
+            compatibility_mode="legacy",
+        )
+        self.mock_ad_connection.search.return_value = []
+
+        with patch(
+            "python_apis.services.ad_group_service.resolve_service_compatibility_mode",
+            return_value="mixed",
+        ) as mock_resolve:
+            service.get_groups_from_ad(compatibility_mode="mixed")
+
+        mock_resolve.assert_called_with(per_call_mode="mixed", service_mode="legacy")
+
+    def test_ou_read_operation_accepts_per_call_override(self):
+        service = ADOrganizationalUnitService(
+            ad_connection=self.mock_ad_connection,
+            sql_connection=self.mock_sql_connection,
+            compatibility_mode="legacy",
+        )
+        self.mock_ad_connection.search.return_value = []
+
+        with patch(
+            "python_apis.services.ad_ou_service.resolve_service_compatibility_mode",
+            return_value="mixed",
+        ) as mock_resolve:
+            service.get_ous_from_ad(compatibility_mode="mixed")
+
+        mock_resolve.assert_called_with(per_call_mode="mixed", service_mode="legacy")
 
 
 if __name__ == "__main__":

--- a/src/tests/test_services/test_ad_service_compatibility_mode.py
+++ b/src/tests/test_services/test_ad_service_compatibility_mode.py
@@ -1,0 +1,63 @@
+"""Tests for service-level default compatibility mode resolution."""
+
+import os
+import unittest
+from unittest.mock import MagicMock
+
+from python_apis.services import (
+    ADGroupService,
+    ADOrganizationalUnitService,
+    ADUserService,
+)
+from python_apis.services.compatibility_mode import AD_COMPATIBILITY_ENV_VAR
+
+
+class TestServiceCompatibilityModeDefaults(unittest.TestCase):
+    """Validate compatibility mode defaults across AD service constructors."""
+
+    def setUp(self):
+        self.mock_ad_connection = MagicMock()
+        self.mock_sql_connection = MagicMock()
+
+    def tearDown(self):
+        os.environ.pop(AD_COMPATIBILITY_ENV_VAR, None)
+
+    def test_user_service_defaults_to_legacy(self):
+        service = ADUserService(
+            ad_connection=self.mock_ad_connection,
+            sql_connection=self.mock_sql_connection,
+        )
+
+        self.assertEqual(service.compatibility_mode, "legacy")
+
+    def test_user_service_uses_explicit_mode(self):
+        service = ADUserService(
+            ad_connection=self.mock_ad_connection,
+            sql_connection=self.mock_sql_connection,
+            compatibility_mode="strict",
+        )
+
+        self.assertEqual(service.compatibility_mode, "strict")
+
+    def test_group_service_uses_environment_mode(self):
+        os.environ[AD_COMPATIBILITY_ENV_VAR] = "mixed"
+
+        service = ADGroupService(
+            ad_connection=self.mock_ad_connection,
+            sql_connection=self.mock_sql_connection,
+        )
+
+        self.assertEqual(service.compatibility_mode, "mixed")
+
+    def test_ou_service_invalid_mode_falls_back_to_legacy(self):
+        service = ADOrganizationalUnitService(
+            ad_connection=self.mock_ad_connection,
+            sql_connection=self.mock_sql_connection,
+            compatibility_mode="invalid-mode",
+        )
+
+        self.assertEqual(service.compatibility_mode, "legacy")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_services/test_compatibility_mode.py
+++ b/src/tests/test_services/test_compatibility_mode.py
@@ -13,8 +13,14 @@ from python_apis.services.compatibility_mode import (
 class TestCompatibilityModeUtility(unittest.TestCase):
     """Validate deterministic AD compatibility mode resolution behavior."""
 
+    def setUp(self):
+        self.original_env_value = os.environ.get(AD_COMPATIBILITY_ENV_VAR)
+
     def tearDown(self):
-        os.environ.pop(AD_COMPATIBILITY_ENV_VAR, None)
+        if self.original_env_value is None:
+            os.environ.pop(AD_COMPATIBILITY_ENV_VAR, None)
+            return
+        os.environ[AD_COMPATIBILITY_ENV_VAR] = self.original_env_value
 
     def test_resolves_per_call_mode_first(self):
         os.environ[AD_COMPATIBILITY_ENV_VAR] = "strict"

--- a/src/tests/test_services/test_compatibility_mode.py
+++ b/src/tests/test_services/test_compatibility_mode.py
@@ -1,0 +1,60 @@
+"""Tests for service-layer compatibility mode resolver utilities."""
+
+import os
+import unittest
+
+from python_apis.services.compatibility_mode import (
+    AD_COMPATIBILITY_ENV_VAR,
+    AD_DEFAULT_COMPATIBILITY_MODE,
+    resolve_service_compatibility_mode,
+)
+
+
+class TestCompatibilityModeUtility(unittest.TestCase):
+    """Validate deterministic AD compatibility mode resolution behavior."""
+
+    def tearDown(self):
+        os.environ.pop(AD_COMPATIBILITY_ENV_VAR, None)
+
+    def test_resolves_per_call_mode_first(self):
+        os.environ[AD_COMPATIBILITY_ENV_VAR] = "strict"
+
+        result = resolve_service_compatibility_mode(
+            per_call_mode="mixed",
+            service_mode="legacy",
+        )
+
+        self.assertEqual(result, "mixed")
+
+    def test_resolves_service_mode_when_per_call_missing(self):
+        os.environ[AD_COMPATIBILITY_ENV_VAR] = "strict"
+
+        result = resolve_service_compatibility_mode(service_mode="mixed")
+
+        self.assertEqual(result, "mixed")
+
+    def test_resolves_environment_mode_when_no_explicit_modes(self):
+        os.environ[AD_COMPATIBILITY_ENV_VAR] = "strict"
+
+        result = resolve_service_compatibility_mode()
+
+        self.assertEqual(result, "strict")
+
+    def test_falls_back_to_legacy_for_invalid_mode(self):
+        result = resolve_service_compatibility_mode(per_call_mode="invalid")
+
+        self.assertEqual(result, AD_DEFAULT_COMPATIBILITY_MODE)
+
+    def test_falls_back_to_legacy_for_empty_modes(self):
+        os.environ[AD_COMPATIBILITY_ENV_VAR] = "   "
+
+        result = resolve_service_compatibility_mode(
+            per_call_mode="",
+            service_mode="  ",
+        )
+
+        self.assertEqual(result, AD_DEFAULT_COMPATIBILITY_MODE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description
Implements the Stage N compatibility-mode rollout for AD APIs/services so consumers can adopt modern behavior incrementally without breaking existing integrations.

SemVer intent: `semver:minor` (backward-compatible additive).

## Changes
- Added shared AD compatibility contract and resolver primitives in [src/python_apis/apis/ad_api.py](src/python_apis/apis/ad_api.py) and exported from [src/python_apis/apis/__init__.py](src/python_apis/apis/__init__.py).
- Added service-layer compatibility utility and exports in [src/python_apis/services/compatibility_mode.py](src/python_apis/services/compatibility_mode.py) and [src/python_apis/services/__init__.py](src/python_apis/services/__init__.py).
- Wired AD service defaults, per-call mode overrides for read paths, and introspection APIs in:
  - [src/python_apis/services/ad_user_service.py](src/python_apis/services/ad_user_service.py)
  - [src/python_apis/services/ad_group_service.py](src/python_apis/services/ad_group_service.py)
  - [src/python_apis/services/ad_ou_service.py](src/python_apis/services/ad_ou_service.py)
- Updated tests for resolver precedence, default behavior, override behavior, and introspection in:
  - [src/tests/test_apis/test_ad_api.py](src/tests/test_apis/test_ad_api.py)
  - [src/tests/test_services/test_compatibility_mode.py](src/tests/test_services/test_compatibility_mode.py)
  - [src/tests/test_services/test_ad_service_compatibility_mode.py](src/tests/test_services/test_ad_service_compatibility_mode.py)
- Added Unreleased changelog entry in [CHANGELOG.md](CHANGELOG.md).

## Testing
- `python -m unittest discover -s src/tests -p "test_*.py"`
- `pylint src/python_apis/`
- Targeted compatibility tests:
  - `python -m unittest src/tests/test_apis/test_ad_api.py`
  - `python -m unittest src/tests/test_services/test_compatibility_mode.py`
  - `python -m unittest src/tests/test_services/test_ad_service_compatibility_mode.py`

Closes #17