### PR TITLE
feat(#19): add AD operation envelope with legacy key mirroring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   serialization (additive, non-breaking; exported from `python_apis.models`)
 - Contract tests pinning AD response model field names, types, dict-compatibility, and JSON
   serializability
+- AD operation envelope (`ADOperationEnvelope`) for service write operations with
+  compatibility-mode-driven legacy key mirroring (`success`/`result`/`message`), modern fields
+  (`operation_kind`, `ldap_result`, `exception_type`/`exception_message`, `request_context`), and
+  forward-compatible defaults (`error_code`, `retry_count`, `retried`); wired into
+  `ADUserService`, `ADGroupService`, and `ADOrganizationalUnitService` write ops with optional
+  per-call `compatibility_mode` overrides (additive, non-breaking; `legacy` returns the historic
+  dict unchanged, `mixed` mirrors legacy keys, `strict` omits them)
+- Service-layer envelope contract tests across user/group/OU write operations
+- Migration guide for the AD operation envelope (`docs/migration/ad-operation-envelope.md`)
 
 ### Fixed
 

--- a/docs/migration/ad-operation-envelope.md
+++ b/docs/migration/ad-operation-envelope.md
@@ -1,0 +1,160 @@
+# Migration Guide: AD Operation Envelope (Issue #19)
+
+> Status: Stage N (additive, non-breaking)
+> Related: [ADR 0001](../adr/0001-ad-response-modernization.md), issues #17, #18, #19
+
+Issue #19 introduces a consistent **operation envelope** for AD service write
+operations, built on the dict-compatible response models from #18. The envelope
+adds modern, machine-routable metadata while preserving the legacy dict shape
+under the default `legacy` compatibility mode.
+
+This guide shows before/after usage and how each compatibility mode shapes the
+returned payload.
+
+## Envelope fields
+
+The envelope (`ADOperationEnvelope`) exposes the following modern fields:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `success` | `bool` | Operation outcome. |
+| `operation_kind` | `"read"` \| `"write"` | Distinguishes read vs. write paths. |
+| `ldap_result` | `Any` | Raw LDAP result (mirrored as legacy `result`). |
+| `exception_type` | `str \| None` | Exception class name when an error was captured. |
+| `exception_message` | `str \| None` | Exception text (mirrored as legacy `message`). |
+| `request_context` | `dict[str, Any]` | Operation extras (`changes`, `dn`, ...) plus `compatibility_mode`. |
+| `retry_count` | `int` | Forward-compatible default `0` (populated by #21). |
+| `retried` | `bool` | Forward-compatible default `False` (populated by #21). |
+| `error_code` | `str \| None` | Forward-compatible default `None` (taxonomy in #20). |
+
+Legacy mirror keys `success`, `result`, and `message` remain available in
+`legacy` and `mixed` modes.
+
+## Compatibility modes at a glance
+
+| Mode | Legacy keys (`result`, `message`) | Modern envelope fields | Stage N default |
+| --- | --- | --- | --- |
+| `legacy` | Present (dict returned unchanged) | Not added | Yes |
+| `mixed` | Present (mirrored) | Present | No (opt-in) |
+| `strict` | Omitted | Present | No (opt-in) |
+
+Mode precedence: per-call `compatibility_mode` argument -> service default ->
+`PYTHON_APIS_AD_COMPAT_MODE` environment variable -> `legacy` fallback.
+
+## Write path: before / after
+
+### Before (legacy, unchanged default)
+
+```python
+service = ADGroupService()  # defaults to legacy
+result = service.modify_group(group, [("description", "new")])
+
+# Legacy dict shape is preserved exactly:
+# {
+#     "success": True,
+#     "result": "ok",
+#     "changes": {"description": "old -> new"},
+# }
+if result["success"]:
+    ...
+```
+
+Existing consumers reading `result["success"]` / `result["result"]` continue to
+work with no changes.
+
+### After (opt-in modern envelope)
+
+```python
+# Opt in per call ...
+result = service.modify_group(
+    group, [("description", "new")], compatibility_mode="mixed"
+)
+
+# ... or per service instance / environment.
+service = ADGroupService(compatibility_mode="mixed")
+```
+
+`mixed` mode output (legacy mirrors + modern fields):
+
+```python
+{
+    "success": True,
+    "operation_kind": "write",
+    "ldap_result": "ok",
+    "result": "ok",            # legacy mirror of ldap_result
+    "exception_type": None,
+    "exception_message": None,
+    "message": None,           # legacy mirror of exception_message
+    "request_context": {
+        "changes": {"description": "old -> new"},
+        "compatibility_mode": "mixed",
+    },
+    "retry_count": 0,
+    "retried": False,
+    "error_code": None,
+    "changes": {"description": "old -> new"},
+}
+```
+
+`strict` mode output (modern only; legacy `result`/`message` omitted):
+
+```python
+{
+    "success": True,
+    "operation_kind": "write",
+    "ldap_result": "ok",
+    "exception_type": None,
+    "exception_message": None,
+    "request_context": {
+        "changes": {"description": "old -> new"},
+        "compatibility_mode": "strict",
+    },
+    "retry_count": 0,
+    "retried": False,
+    "error_code": None,
+    "changes": {"description": "old -> new"},
+}
+```
+
+### Exception paths
+
+When a write raises an `LDAPException`, the envelope captures the failure
+(`mixed`/`strict`):
+
+```python
+{
+    "success": False,
+    "operation_kind": "write",
+    "ldap_result": "boom",
+    "exception_type": "LDAPException",
+    "exception_message": "boom",
+    # legacy mirrors `result`/`message` present in mixed, omitted in strict
+    ...
+}
+```
+
+In `legacy` mode the historic shape is preserved unchanged:
+`{"success": False, "result": "boom"}`.
+
+## Read path
+
+Read operations already return typed, dict-compatible responses from #18
+(`ADEntry` / `ADSearchResponse`). They are intentionally **out of scope** for
+envelope conversion in #19 to keep the `semver:minor` contract non-breaking;
+`operation_kind` still distinguishes `read` from `write` for the shared builder
+and future read adoption. Continue reading entries as mappings:
+
+```python
+users = service.get_users_from_ad()  # list[ADUser]
+for user in users:
+    name = user["sAMAccountName"]  # dict-compatible access
+```
+
+## Recommended adoption path
+
+1. Stay on `legacy` (default) — no changes required.
+2. Opt into `mixed` to consume modern fields while legacy keys remain mirrored.
+3. Move to `strict` once consumers no longer read legacy `result`/`message`.
+
+Legacy mirror removal is gated to a future `semver:major` stage (N+2) per
+ADR 0001; do not rely on mirrors being removed before then.

--- a/src/python_apis/models/__init__.py
+++ b/src/python_apis/models/__init__.py
@@ -10,6 +10,7 @@ from python_apis.models.ad_ou import ADOrganizationalUnit
 from python_apis.models.ad_responses import (
     ADResponse,
     ADOperationResponse,
+    ADOperationEnvelope,
     ADEntry,
     ADSearchResponse,
 )
@@ -25,6 +26,7 @@ __all__ = [
 
     "ADResponse",
     "ADOperationResponse",
+    "ADOperationEnvelope",
     "ADEntry",
     "ADSearchResponse",
 

--- a/src/python_apis/models/ad_responses.py
+++ b/src/python_apis/models/ad_responses.py
@@ -168,6 +168,77 @@ class ADOperationEnvelope(ADResponse):
 
         return self.exception_message
 
+    @classmethod
+    def from_operation(  # pylint: disable=too-many-arguments
+        cls,
+        *,
+        operation_kind: Literal["read", "write"],
+        success: bool | None = None,
+        ldap_result: Any = None,
+        exception: BaseException | None = None,
+        request_context: dict[str, Any] | None = None,
+        retry_count: int = 0,
+        retried: bool = False,
+        error_code: str | None = None,
+    ) -> "ADOperationEnvelope":
+        """Build an envelope from an AD operation outcome.
+
+        Captures the structured result of a single AD operation. When
+        ``exception`` is provided, ``exception_type`` and ``exception_message``
+        are derived from it and ``success`` defaults to ``False``; otherwise
+        ``success`` defaults to ``True`` unless explicitly supplied.
+
+        ``retry_count``/``retried``/``error_code`` are accepted now for forward
+        compatibility with retry telemetry (issue #21) and the normalized error
+        taxonomy (issue #20); both currently default to safe values.
+        """
+
+        exception_type: str | None = None
+        exception_message: str | None = None
+        if exception is not None:
+            exception_type = type(exception).__name__
+            exception_message = str(exception)
+
+        if success is None:
+            success = exception is None
+
+        return cls(
+            success=success,
+            operation_kind=operation_kind,
+            ldap_result=ldap_result,
+            exception_type=exception_type,
+            exception_message=exception_message,
+            request_context=request_context or {},
+            retry_count=retry_count,
+            retried=retried,
+            error_code=error_code,
+        )
+
+    def to_response(self, mode: str | None = None) -> dict[str, Any]:
+        """Return the envelope as a dict shaped for the given compatibility mode.
+
+        - ``legacy``/``mixed``: include legacy mirror keys (``success``,
+          ``result``, ``message``) alongside modern fields.
+        - ``strict``: omit legacy mirror keys and return only the modern
+          envelope fields.
+
+        Any unknown or empty ``mode`` resolves to ``legacy`` via
+        :func:`resolve_ad_compatibility_mode`, preserving a non-breaking default.
+        """
+
+        # Imported lazily to avoid a circular import: ``models`` is imported by
+        # the package ``__init__`` before ``apis`` finishes initializing.
+        from python_apis.apis.ad_api import (  # pylint: disable=import-outside-toplevel
+            resolve_ad_compatibility_mode,
+        )
+
+        resolved = resolve_ad_compatibility_mode(per_call_mode=mode)
+        payload = self.to_dict()
+        if resolved == "strict":
+            for legacy_key in ("result", "message"):
+                payload.pop(legacy_key, None)
+        return payload
+
 
 class ADEntry(ADResponse):
     """Typed, dict-compatible representation of a single AD object.

--- a/src/python_apis/models/ad_responses.py
+++ b/src/python_apis/models/ad_responses.py
@@ -14,9 +14,9 @@ Stage N scope note:
 """
 
 from collections.abc import Callable, Iterator, Mapping, Sequence
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, computed_field
 
 _ADResponseT = TypeVar("_ADResponseT", bound="ADResponse")
 
@@ -41,9 +41,12 @@ class ADResponse(BaseModel, Mapping):
     _missing_default_factory: Callable[[], Any] | None = PrivateAttr(default=None)
 
     def _mapping_keys(self) -> list[str]:
-        """Return the ordered key surface (declared fields then extras)."""
+        """Return the ordered key surface (fields, computed fields, then extras)."""
 
         keys = list(type(self).model_fields.keys())
+        keys.extend(
+            key for key in type(self).model_computed_fields.keys() if key not in keys
+        )
         extra = self.model_extra or {}
         keys.extend(key for key in extra if key not in keys)
         return keys
@@ -57,6 +60,8 @@ class ADResponse(BaseModel, Mapping):
         """
 
         if key in list(type(self).model_fields.keys()):
+            return getattr(self, key)
+        if key in list(type(self).model_computed_fields.keys()):
             return getattr(self, key)
         extra = self.model_extra or {}
         if key in extra:
@@ -123,6 +128,47 @@ class ADOperationResponse(ADResponse):
     result: Any = None
 
 
+class ADOperationEnvelope(ADResponse):
+    """Consistent operation envelope for AD service calls (ADR 0001, Stage N).
+
+    Provides modern, structured metadata for an AD operation while mirroring the
+    legacy top-level keys (``success``, ``result``, ``message``) so existing
+    consumers keep working during the migration. ``result`` mirrors
+    ``ldap_result`` and ``message`` mirrors ``exception_message``; the mirror
+    values never diverge from their modern counterparts.
+
+    Forward-compatible fields are included now with safe defaults so the
+    envelope shape stays stable across the rollout:
+
+    - ``error_code`` is populated by the normalized error taxonomy (issue #20).
+    - ``retry_count`` / ``retried`` are populated by retry telemetry (issue #21).
+    """
+
+    success: bool
+    operation_kind: Literal["read", "write"]
+    ldap_result: Any = None
+    exception_type: str | None = None
+    exception_message: str | None = None
+    request_context: dict[str, Any] = Field(default_factory=dict)
+    retry_count: int = 0
+    retried: bool = False
+    error_code: str | None = None
+
+    @computed_field
+    @property
+    def result(self) -> Any:
+        """Legacy mirror of :attr:`ldap_result`."""
+
+        return self.ldap_result
+
+    @computed_field
+    @property
+    def message(self) -> str | None:
+        """Legacy mirror of :attr:`exception_message`."""
+
+        return self.exception_message
+
+
 class ADEntry(ADResponse):
     """Typed, dict-compatible representation of a single AD object.
 
@@ -176,8 +222,10 @@ class ADSearchResponse(BaseModel, Sequence):
 
 
 __all__: list[str] = [
+    # pylint: disable=duplicate-code
     "ADResponse",
     "ADOperationResponse",
+    "ADOperationEnvelope",
     "ADEntry",
     "ADSearchResponse",
 ]

--- a/src/python_apis/services/ad_group_service.py
+++ b/src/python_apis/services/ad_group_service.py
@@ -15,7 +15,10 @@ from dev_tools import timing_decorator
 from python_apis.apis import ADConnection, SQLConnection
 from python_apis.models import ADGroup, base
 from python_apis.schemas import ADGroupSchema
-from python_apis.services.compatibility_mode import resolve_service_compatibility_mode
+from python_apis.services.compatibility_mode import (
+    finalize_ad_write_response,
+    resolve_service_compatibility_mode,
+)
 
 class ADGroupService:
     """Service class for interacting with Active Directory groups.
@@ -193,7 +196,11 @@ class ADGroupService:
         return ad_groups
 
     def modify_group(
-        self, group: ADGroup, changes: list[tuple[str, Any]]) -> dict[str, Any]:
+        self,
+        group: ADGroup,
+        changes: list[tuple[str, Any]],
+        compatibility_mode: str | None = None,
+    ) -> dict[str, Any]:
         """Modify attributes of a group in Active Directory.
 
         Args:
@@ -205,6 +212,8 @@ class ADGroupService:
                         ('description', 'New Description'),
                         ('managedBy', 'CN=Manager,OU=Users,DC=example,DC=com'),
                     ]
+            compatibility_mode (str | None): Optional per-call compatibility mode
+                override controlling the response envelope shape.
 
         Returns:
             dict[str, Any]: A dictionary containing the result of the modify operation with the
@@ -214,6 +223,7 @@ class ADGroupService:
                 - 'changes' (dict[str, Any]): A mapping of attribute names to their changes in the
                 format 'old_value -> new_value'.
         """
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
         change_affects = {k: f"{getattr(group, k)} -> {v}" for k, v in changes}
         try:
             response = self.ad_connection.modify(group.distinguishedName, changes)
@@ -224,7 +234,11 @@ class ADGroupService:
                 change_affects,
                 str(e),
             )
-            return {'success': False, 'result': str(e)}
+            return finalize_ad_write_response(
+                {'success': False, 'result': str(e)},
+                effective_mode=effective_mode,
+                exception=e,
+            )
 
         if response is None:
             self.logger.warning(
@@ -241,11 +255,14 @@ class ADGroupService:
                 response.get("result"),
                 change_affects,
             )
-        return {
-            'success': response.get('success', False),
-            'result': response.get('result'),
-            'changes': change_affects,
-        }
+        return finalize_ad_write_response(
+            {
+                'success': response.get('success', False),
+                'result': response.get('result'),
+                'changes': change_affects,
+            },
+            effective_mode=effective_mode,
+        )
 
     @staticmethod
     def attributes() -> list[str]:

--- a/src/python_apis/services/ad_ou_service.py
+++ b/src/python_apis/services/ad_ou_service.py
@@ -16,7 +16,10 @@ from dev_tools import timing_decorator
 from python_apis.apis import ADConnection, SQLConnection
 from python_apis.models import ADOrganizationalUnit, base
 from python_apis.schemas import ADOrganizationalUnitSchema
-from python_apis.services.compatibility_mode import resolve_service_compatibility_mode
+from python_apis.services.compatibility_mode import (
+    finalize_ad_write_response,
+    resolve_service_compatibility_mode,
+)
 
 class ADOrganizationalUnitService:
     """Service class for interacting with Active Directory organizational units.
@@ -244,7 +247,11 @@ class ADOrganizationalUnitService:
         return ad_ous
 
     def modify_ou(
-        self, ou: ADOrganizationalUnit, changes: list[tuple[str, str]]) -> dict[str, Any]:
+        self,
+        ou: ADOrganizationalUnit,
+        changes: list[tuple[str, str]],
+        compatibility_mode: str | None = None,
+    ) -> dict[str, Any]:
         """Modify attributes of a organizational unit in Active Directory.
 
         Args:
@@ -253,6 +260,8 @@ class ADOrganizationalUnitService:
                 Each tuple consists of an attribute name and its new value.
                 For example:
                     [('name', 'John'), ('description', 'Doe')]
+            compatibility_mode (str | None): Optional per-call compatibility mode
+                override controlling the response envelope shape.
 
         Returns:
             dict[str, Any]: A dictionary containing the result of the modify operation with the
@@ -262,6 +271,7 @@ class ADOrganizationalUnitService:
                 - 'changes' (dict[str, str]): A mapping of attribute names to their changes in the
                 format 'old_value -> new_value'.
         """
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
         change_affects = {k: f"{getattr(ou, k)} -> {v}" for k, v in changes}
         try:
             response = self.ad_connection.modify(ou.distinguishedName, changes)
@@ -272,7 +282,11 @@ class ADOrganizationalUnitService:
                 change_affects,
                 str(e),
             )
-            return {'success': False, 'result': str(e)}
+            return finalize_ad_write_response(
+                {'success': False, 'result': str(e)},
+                effective_mode=effective_mode,
+                exception=e,
+            )
 
         if response is None:
             self.logger.warning(
@@ -289,11 +303,14 @@ class ADOrganizationalUnitService:
                 response.get("result"),
                 change_affects,
             )
-        return {
-            'success': response.get('success', False),
-            'result': response.get('result'),
-            'changes': change_affects,
-        }
+        return finalize_ad_write_response(
+            {
+                'success': response.get('success', False),
+                'result': response.get('result'),
+                'changes': change_affects,
+            },
+            effective_mode=effective_mode,
+        )
 
     @staticmethod
     def attributes() -> list[str]:

--- a/src/python_apis/services/ad_user_service.py
+++ b/src/python_apis/services/ad_user_service.py
@@ -14,6 +14,7 @@ from pydantic import ValidationError
 from dev_tools import timing_decorator
 from python_apis.apis import ADConnection, SQLConnection
 from python_apis.models import ADUser
+from python_apis.models import ADOperationEnvelope
 from python_apis.schemas import ADUserSchema
 from python_apis.services.compatibility_mode import resolve_service_compatibility_mode
 
@@ -65,6 +66,47 @@ class ADUserService:
             per_call_mode=compatibility_mode,
             service_mode=self.compatibility_mode,
         )
+
+    def _finalize_write(
+        self,
+        legacy_response: dict[str, Any],
+        *,
+        effective_mode: str,
+        exception: BaseException | None = None,
+    ) -> dict[str, Any]:
+        """Shape a write-operation response for the effective compatibility mode.
+
+        In ``legacy`` mode the original response dict is returned unchanged to
+        preserve pre-modernization behavior (non-breaking default). In ``mixed``
+        and ``strict`` modes an :class:`ADOperationEnvelope` is emitted: ``mixed``
+        mirrors the legacy keys (``success``, ``result``, ``message``) while
+        ``strict`` omits them. Operation-specific extras (for example ``dn`` or
+        ``changes``) are preserved as top-level keys and captured in
+        ``request_context``.
+        """
+
+        if effective_mode == "legacy":
+            return legacy_response
+
+        extras = {
+            key: value
+            for key, value in legacy_response.items()
+            if key not in ("success", "result")
+        }
+        success = (
+            False if exception is not None else bool(legacy_response.get("success"))
+        )
+        envelope = ADOperationEnvelope.from_operation(
+            operation_kind="write",
+            success=success,
+            ldap_result=legacy_response.get("result"),
+            exception=exception,
+            request_context={**extras, "compatibility_mode": effective_mode},
+        )
+        payload = envelope.to_response(effective_mode)
+        for key, value in extras.items():
+            payload.setdefault(key, value)
+        return payload
 
     def get_compatibility_mode(self, compatibility_mode: str | None = None) -> dict[str, str]:
         """Return service default and effective compatibility mode for this context."""
@@ -203,69 +245,98 @@ class ADUserService:
                              in ad_users_dict if 'sAMAccountName' in user}
         return sam_account_names
 
-    def enable_user(self, user: ADUser | str) -> dict[str, Any]:
+    def enable_user(
+        self, user: ADUser | str, compatibility_mode: str | None = None
+    ) -> dict[str, Any]:
         """Enable an Active Directory user.
 
         Args:
             user (ADUser | str): The user (or distinguishedName) to enable.
+            compatibility_mode (str | None): Optional per-call compatibility mode
+                override controlling the response envelope shape.
 
         Returns:
             dict[str, Any]: The result of the enable operation.
         """
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
         distinguished_name = (user.distinguishedName
                               if isinstance(user, ADUser)
                               else str(user))
-        return self.ad_connection.enable_user(distinguished_name)
+        response = self.ad_connection.enable_user(distinguished_name)
+        return self._finalize_write(response, effective_mode=effective_mode)
 
-    def disable_user(self, user: ADUser | str) -> dict[str, Any]:
+    def disable_user(
+        self, user: ADUser | str, compatibility_mode: str | None = None
+    ) -> dict[str, Any]:
         """Disable an Active Directory user.
 
         Args:
             user (ADUser | str): The user (or distinguishedName) to disable.
+            compatibility_mode (str | None): Optional per-call compatibility mode
+                override controlling the response envelope shape.
 
         Returns:
             dict[str, Any]: The result of the disable operation.
         """
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
         distinguished_name = (user.distinguishedName
                               if isinstance(user, ADUser)
                               else str(user))
-        return self.ad_connection.disable_user(distinguished_name)
+        response = self.ad_connection.disable_user(distinguished_name)
+        return self._finalize_write(response, effective_mode=effective_mode)
 
-    def add_member(self, user: ADUser, group_dn: str) -> dict[str, Any]:
+    def add_member(
+        self, user: ADUser, group_dn: str, compatibility_mode: str | None = None
+    ) -> dict[str, Any]:
         """Add a user to an Active Directory group.
 
         Args:
             user (ADUser): The user to add.
             group_dn (str): The distinguished name of the group.
+            compatibility_mode (str | None): Optional per-call compatibility mode
+                override controlling the response envelope shape.
 
         Returns:
             dict[str, Any]: The result of the add operation.
         """
-        return self.ad_connection.add_member(user.distinguishedName, group_dn)
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
+        response = self.ad_connection.add_member(user.distinguishedName, group_dn)
+        return self._finalize_write(response, effective_mode=effective_mode)
 
-    def remove_member(self, user: ADUser, group_dn: str) -> dict[str, Any]:
+    def remove_member(
+        self, user: ADUser, group_dn: str, compatibility_mode: str | None = None
+    ) -> dict[str, Any]:
         """Remove a user from an Active Directory group.
 
         Args:
             user (ADUser): The user to remove.
             group_dn (str): The distinguished name of the group.
+            compatibility_mode (str | None): Optional per-call compatibility mode
+                override controlling the response envelope shape.
 
         Returns:
             dict[str, Any]: The result of the remove operation.
         """
-        return self.ad_connection.remove_member(user.distinguishedName, group_dn)
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
+        response = self.ad_connection.remove_member(user.distinguishedName, group_dn)
+        return self._finalize_write(response, effective_mode=effective_mode)
 
-    def move_user_to_ou(self, user: ADUser, target_ou_dn: str) -> dict[str, Any]:
+    def move_user_to_ou(
+        self, user: ADUser, target_ou_dn: str, compatibility_mode: str | None = None
+    ) -> dict[str, Any]:
         """Move a user to a different OU in Active Directory.
 
         Args:
             user (ADUser): The user to move.
             target_ou_dn (str): Distinguished name for the destination OU.
+            compatibility_mode (str | None): Optional per-call compatibility mode
+                override controlling the response envelope shape.
 
         Returns:
             dict[str, Any]: Result payload from the move operation including success flag.
         """
 
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
         current_dn = user.distinguishedName
         try:
             response = self.ad_connection.move_entry(str(current_dn), target_ou_dn)
@@ -276,7 +347,11 @@ class ADUserService:
                 target_ou_dn,
                 str(e),
             )
-            return {'success': False, 'result': str(e)}
+            return self._finalize_write(
+                {'success': False, 'result': str(e)},
+                effective_mode=effective_mode,
+                exception=e,
+            )
 
         result = dict(response) if response is not None else {'success': False, 'result': None}
         if not result.get('success'):
@@ -286,7 +361,7 @@ class ADUserService:
                 target_ou_dn,
                 result.get('result'),
             )
-            return result
+            return self._finalize_write(result, effective_mode=effective_mode)
 
         new_dn = self._user_dn(str(user.cn), target_ou_dn)
         setattr(user, 'distinguishedName', new_dn)
@@ -297,9 +372,14 @@ class ADUserService:
             getattr(user, 'sAMAccountName', '<unknown>'),
             target_ou_dn,
         )
-        return result
+        return self._finalize_write(result, effective_mode=effective_mode)
 
-    def modify_user(self, user: ADUser, changes: list[tuple[str, str]]) -> dict[str, Any]:
+    def modify_user(
+        self,
+        user: ADUser,
+        changes: list[tuple[str, str]],
+        compatibility_mode: str | None = None,
+    ) -> dict[str, Any]:
         """Modify attributes of a user in Active Directory.
 
         Args:
@@ -308,6 +388,8 @@ class ADUserService:
                 Each tuple consists of an attribute name and its new value.
                 For example:
                     [('givenName', 'John'), ('sn', 'Doe')]
+            compatibility_mode (str | None): Optional per-call compatibility mode
+                override controlling the response envelope shape.
 
         Returns:
             dict[str, Any]: A dictionary containing the result of the modify operation with the
@@ -317,6 +399,7 @@ class ADUserService:
                 - 'changes' (dict[str, str]): A mapping of attribute names to their changes in the
                 format 'old_value -> new_value'.
         """
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
         change_affects = {k: f"{getattr(user, k)} -> {v}" for k, v in changes}
         try:
             response = self.ad_connection.modify(user.distinguishedName, changes)
@@ -329,7 +412,11 @@ class ADUserService:
                 change_affects,
                 str(e),
             )
-            return {'success': False, 'result': str(e)}
+            return self._finalize_write(
+                {'success': False, 'result': str(e)},
+                effective_mode=effective_mode,
+                exception=e,
+            )
 
         if response is None:
             self.logger.warning(
@@ -346,11 +433,14 @@ class ADUserService:
                 response.get("result"),
                 change_affects,
             )
-        return {
-            'success': response.get('success', False),
-            'result': response.get('result'),
-            'changes': change_affects,
-        }
+        return self._finalize_write(
+            {
+                'success': response.get('success', False),
+                'result': response.get('result'),
+                'changes': change_affects,
+            },
+            effective_mode=effective_mode,
+        )
 
     @staticmethod
     def attributes() -> list[str]:
@@ -376,6 +466,7 @@ class ADUserService:
         new_password: str,
         *,
         must_change_at_next_logon: bool = False,
+        compatibility_mode: str | None = None,
     ) -> dict[str, Any]:
         """Set a new password for the specified user.
 
@@ -384,10 +475,13 @@ class ADUserService:
             new_password (str): The new password to set.
             must_change_at_next_logon (bool): If True, forces the user to change
                 their password at the next logon. Defaults to False.
+            compatibility_mode (str | None): Optional per-call compatibility mode
+                override controlling the response envelope shape.
 
         Returns:
             dict[str, Any]: Result payload with 'success' and 'result' keys.
         """
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
         distinguished_name = (user.distinguishedName
                               if isinstance(user, ADUser)
                               else str(user))
@@ -399,7 +493,10 @@ class ADUserService:
             if not response.get('success'):
                 self.logger.warning("Failed to set password for user %s: %s", account_label,
                                     response.get('result'))
-                return {'success': False, 'result': response.get('result')}
+                return self._finalize_write(
+                    {'success': False, 'result': response.get('result')},
+                    effective_mode=effective_mode,
+                )
 
             if must_change_at_next_logon:
                 force_resp = self.ad_connection.force_change_password_at_next_logon(
@@ -410,22 +507,32 @@ class ADUserService:
                         "Failed to set 'must change password' for user %s: %s",
                         account_label, force_resp.get('result')
                     )
-                    return {
-                        'success': False,
-                        'result': {
-                            'password': response.get('result'),
-                            'must_change': force_resp.get('result'),
+                    return self._finalize_write(
+                        {
+                            'success': False,
+                            'result': {
+                                'password': response.get('result'),
+                                'must_change': force_resp.get('result'),
+                            },
                         },
-                    }
+                        effective_mode=effective_mode,
+                    )
         except LDAPException as e:
             self.logger.error("Exception occurred while setting password for user %s: %s",
                               account_label, str(e))
-            return {'success': False, 'result': str(e)}
+            return self._finalize_write(
+                {'success': False, 'result': str(e)},
+                effective_mode=effective_mode,
+                exception=e,
+            )
 
         self.logger.info("Successfully set password for user %s", account_label)
-        return {'success': True, 'result': response.get('result')}
+        return self._finalize_write(
+            {'success': True, 'result': response.get('result')},
+            effective_mode=effective_mode,
+        )
 
-    def create_user(
+    def create_user(  # pylint: disable=too-many-locals
         self,
         cn: str,
         ou_dn: str,
@@ -445,16 +552,20 @@ class ADUserService:
                 at next logon (only applies when set_password is provided)
             - enable_after_create: if True, enables the user after create
                 (requires password set first in most setups)
+            - compatibility_mode: optional per-call compatibility mode override
+                controlling the response envelope shape
         """
         set_password = options.get('set_password')
         must_change_password = options.get('must_change_password_at_next_logon', False)
         enable_after_create = options.get('enable_after_create', False)
         unexpected_options = set(options) - {
-            'set_password', 'must_change_password_at_next_logon', 'enable_after_create'
+            'set_password', 'must_change_password_at_next_logon', 'enable_after_create',
+            'compatibility_mode',
         }
         if unexpected_options:
             raise ValueError(f"Unsupported options provided: {sorted(unexpected_options)}")
 
+        effective_mode = self._resolve_effective_mode(options.get('compatibility_mode'))
         dn = self._user_dn(cn, ou_dn)
 
         # Build attributes for creation (objectClass MUST be present on add)
@@ -466,11 +577,18 @@ class ADUserService:
             response = self.ad_connection.add_entry(dn, create_attrs)
         except LDAPException as e:
             self.logger.error("Failed to create AD user CN=%s in %s: %s", cn, ou_dn, e)
-            return {'success': False, 'result': str(e), 'dn': dn}
+            return self._finalize_write(
+                {'success': False, 'result': str(e), 'dn': dn},
+                effective_mode=effective_mode,
+                exception=e,
+            )
 
         if not response.get('success'):
             self.logger.warning("Create user failed for %s: %s", dn, response.get('result'))
-            return {'success': False, 'result': response.get('result'), 'dn': dn}
+            return self._finalize_write(
+                {'success': False, 'result': response.get('result'), 'dn': dn},
+                effective_mode=effective_mode,
+            )
 
         # Optional: set password then enable
         if set_password:
@@ -480,47 +598,68 @@ class ADUserService:
             if not pw_resp.get('success'):
                 self.logger.warning("Set password failed for %s: %s", dn, pw_resp.get('result'))
                 # You may choose to return failure or proceed; here we surface partial failure:
-                return {
-                    'success': False,
-                    'result': {
-                        'create': response.get('result'),
-                        'password': pw_resp.get('result')
+                return self._finalize_write(
+                    {
+                        'success': False,
+                        'result': {
+                            'create': response.get('result'),
+                            'password': pw_resp.get('result')
+                        },
+                        'dn': dn,
                     },
-                    'dn': dn,
-                }
+                    effective_mode=effective_mode,
+                )
 
         if enable_after_create:
             en_resp = self.enable_user(dn)
             if not en_resp.get('success'):
                 self.logger.warning("Enable user failed for %s: %s", dn, en_resp.get('result'))
-                return {
-                    'success': False,
-                    'result': {'create': response.get('result'), 'enable': en_resp.get('result')},
-                    'dn': dn,
-                }
+                return self._finalize_write(
+                    {
+                        'success': False,
+                        'result': {'create': response.get('result'),
+                                   'enable': en_resp.get('result')},
+                        'dn': dn,
+                    },
+                    effective_mode=effective_mode,
+                )
 
         self.logger.info("Created AD user: %s", dn)
-        return {'success': True, 'result': response.get('result'), 'dn': dn}
+        return self._finalize_write(
+            {'success': True, 'result': response.get('result'), 'dn': dn},
+            effective_mode=effective_mode,
+        )
 
-    def rename_user_cn(self, user: ADUser, new_cn: str) -> dict[str, Any]:
+    def rename_user_cn(
+        self, user: ADUser, new_cn: str, compatibility_mode: str | None = None
+    ) -> dict[str, Any]:
         """
         Rename the user's CN (relative DN) without changing their OU placement.
 
         Args:
             user: The ADUser to rename.
             new_cn: The new common name for the user.
+            compatibility_mode: Optional per-call compatibility mode override
+                controlling the response envelope shape.
 
         Returns:
             Dictionary containing the result of the rename operation.
         """
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
         current_dn = getattr(user, "distinguishedName", None)
         if not current_dn:
-            return {"success": False, "result": "User distinguishedName unavailable"}
+            return self._finalize_write(
+                {"success": False, "result": "User distinguishedName unavailable"},
+                effective_mode=effective_mode,
+            )
 
         # Extract the current OU from the DN (everything after the first comma)
         dn_parts = current_dn.split(',', 1)
         if len(dn_parts) < 2:
-            return {"success": False, "result": "Invalid distinguishedName format"}
+            return self._finalize_write(
+                {"success": False, "result": "Invalid distinguishedName format"},
+                effective_mode=effective_mode,
+            )
 
         current_ou = dn_parts[1]
         new_relative_dn = f"CN={new_cn}"
@@ -540,7 +679,11 @@ class ADUserService:
                 new_cn,
                 str(e),
             )
-            return {'success': False, 'result': str(e)}
+            return self._finalize_write(
+                {'success': False, 'result': str(e)},
+                effective_mode=effective_mode,
+                exception=e,
+            )
 
         result = dict(response) if response is not None else {'success': False, 'result': None}
 
@@ -552,7 +695,7 @@ class ADUserService:
                 new_cn,
                 result.get('result'),
             )
-            return result
+            return self._finalize_write(result, effective_mode=effective_mode)
 
         # Update the user object with the new DN and CN
         setattr(user, 'distinguishedName', new_full_dn)
@@ -569,4 +712,4 @@ class ADUserService:
             new_cn,
         )
 
-        return result
+        return self._finalize_write(result, effective_mode=effective_mode)

--- a/src/python_apis/services/ad_user_service.py
+++ b/src/python_apis/services/ad_user_service.py
@@ -14,9 +14,11 @@ from pydantic import ValidationError
 from dev_tools import timing_decorator
 from python_apis.apis import ADConnection, SQLConnection
 from python_apis.models import ADUser
-from python_apis.models import ADOperationEnvelope
 from python_apis.schemas import ADUserSchema
-from python_apis.services.compatibility_mode import resolve_service_compatibility_mode
+from python_apis.services.compatibility_mode import (
+    finalize_ad_write_response,
+    resolve_service_compatibility_mode,
+)
 
 class ADUserService:
     """Service class for interacting with Active Directory users.
@@ -76,37 +78,16 @@ class ADUserService:
     ) -> dict[str, Any]:
         """Shape a write-operation response for the effective compatibility mode.
 
-        In ``legacy`` mode the original response dict is returned unchanged to
-        preserve pre-modernization behavior (non-breaking default). In ``mixed``
-        and ``strict`` modes an :class:`ADOperationEnvelope` is emitted: ``mixed``
-        mirrors the legacy keys (``success``, ``result``, ``message``) while
-        ``strict`` omits them. Operation-specific extras (for example ``dn`` or
-        ``changes``) are preserved as top-level keys and captured in
-        ``request_context``.
+        Thin wrapper over
+        :func:`python_apis.services.compatibility_mode.finalize_ad_write_response`
+        so all AD services share one envelope/legacy-mirroring implementation.
         """
 
-        if effective_mode == "legacy":
-            return legacy_response
-
-        extras = {
-            key: value
-            for key, value in legacy_response.items()
-            if key not in ("success", "result")
-        }
-        success = (
-            False if exception is not None else bool(legacy_response.get("success"))
-        )
-        envelope = ADOperationEnvelope.from_operation(
-            operation_kind="write",
-            success=success,
-            ldap_result=legacy_response.get("result"),
+        return finalize_ad_write_response(
+            legacy_response,
+            effective_mode=effective_mode,
             exception=exception,
-            request_context={**extras, "compatibility_mode": effective_mode},
         )
-        payload = envelope.to_response(effective_mode)
-        for key, value in extras.items():
-            payload.setdefault(key, value)
-        return payload
 
     def get_compatibility_mode(self, compatibility_mode: str | None = None) -> dict[str, str]:
         """Return service default and effective compatibility mode for this context."""

--- a/src/python_apis/services/compatibility_mode.py
+++ b/src/python_apis/services/compatibility_mode.py
@@ -4,7 +4,7 @@ This module centralizes mode resolution for AD services while reusing the
 contract defined in ``python_apis.apis.ad_api``.
 """
 
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 from python_apis.apis.ad_api import (
     AD_COMPATIBILITY_ENV_VAR,
@@ -12,6 +12,7 @@ from python_apis.apis.ad_api import (
     AD_DEFAULT_COMPATIBILITY_MODE,
     resolve_ad_compatibility_mode,
 )
+from python_apis.models import ADOperationEnvelope
 
 ADCompatibilityMode = Literal["legacy", "mixed", "strict"]
 
@@ -37,10 +38,52 @@ def resolve_service_compatibility_mode(
     )
 
 
+def finalize_ad_write_response(
+    legacy_response: dict[str, Any],
+    *,
+    effective_mode: str,
+    exception: BaseException | None = None,
+) -> dict[str, Any]:
+    """Shape an AD write-operation response for the effective compatibility mode.
+
+    In ``legacy`` mode the original response dict is returned unchanged to
+    preserve pre-modernization behavior (the non-breaking Stage N default). In
+    ``mixed`` and ``strict`` modes an :class:`ADOperationEnvelope` is emitted:
+    ``mixed`` mirrors the legacy keys (``success``, ``result``, ``message``)
+    while ``strict`` omits them. Operation-specific extras (for example ``dn``
+    or ``changes``) are preserved as top-level keys and captured in
+    ``request_context``.
+    """
+
+    if effective_mode == "legacy":
+        return legacy_response
+
+    extras = {
+        key: value
+        for key, value in legacy_response.items()
+        if key not in ("success", "result")
+    }
+    success = (
+        False if exception is not None else bool(legacy_response.get("success"))
+    )
+    envelope = ADOperationEnvelope.from_operation(
+        operation_kind="write",
+        success=success,
+        ldap_result=legacy_response.get("result"),
+        exception=exception,
+        request_context={**extras, "compatibility_mode": effective_mode},
+    )
+    payload = envelope.to_response(effective_mode)
+    for key, value in extras.items():
+        payload.setdefault(key, value)
+    return payload
+
+
 __all__ = [
     "ADCompatibilityMode",
     "AD_COMPATIBILITY_MODES",
     "AD_DEFAULT_COMPATIBILITY_MODE",
     "AD_COMPATIBILITY_ENV_VAR",
     "resolve_service_compatibility_mode",
+    "finalize_ad_write_response",
 ]

--- a/src/tests/test_models/test_ad_responses.py
+++ b/src/tests/test_models/test_ad_responses.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 
 from python_apis.models import (
     ADEntry,
+    ADOperationEnvelope,
     ADOperationResponse,
     ADResponse,
     ADSearchResponse,
@@ -130,6 +131,117 @@ class TestADSearchResponse(unittest.TestCase):
         empty = ADSearchResponse()
         self.assertEqual(len(empty), 0)
         self.assertEqual(empty.to_list(), [])
+
+
+class TestADOperationEnvelope(unittest.TestCase):
+    """Validate the operation envelope model, builder, and mode-aware output."""
+
+    def test_required_fields_and_defaults(self):
+        envelope = ADOperationEnvelope(success=True, operation_kind="write")
+
+        self.assertIs(envelope.success, True)
+        self.assertEqual(envelope.operation_kind, "write")
+        self.assertIsNone(envelope.ldap_result)
+        self.assertIsNone(envelope.exception_type)
+        self.assertIsNone(envelope.exception_message)
+        self.assertEqual(envelope.request_context, {})
+        self.assertEqual(envelope.retry_count, 0)
+        self.assertIs(envelope.retried, False)
+        self.assertIsNone(envelope.error_code)
+
+    def test_legacy_mirrors_match_modern_fields(self):
+        envelope = ADOperationEnvelope(
+            success=True,
+            operation_kind="write",
+            ldap_result={"description": "success"},
+            exception_message="none",
+        )
+
+        # Mirrors readable via attribute and Mapping access.
+        self.assertEqual(envelope.result, envelope.ldap_result)
+        self.assertEqual(envelope.message, envelope.exception_message)
+        self.assertEqual(envelope["result"], envelope.ldap_result)
+        self.assertEqual(envelope["message"], envelope.exception_message)
+
+    def test_json_serializable(self):
+        envelope = ADOperationEnvelope(
+            success=True,
+            operation_kind="write",
+            ldap_result={"description": "success"},
+        )
+        payload = json.loads(envelope.model_dump_json())
+
+        self.assertEqual(payload["result"], {"description": "success"})
+        self.assertEqual(payload["ldap_result"], {"description": "success"})
+
+    def test_from_operation_success(self):
+        envelope = ADOperationEnvelope.from_operation(
+            operation_kind="write",
+            ldap_result={"description": "success"},
+            request_context={"dn": "CN=x"},
+        )
+
+        self.assertIs(envelope.success, True)
+        self.assertIsNone(envelope.exception_type)
+        self.assertEqual(envelope.ldap_result, {"description": "success"})
+        self.assertEqual(envelope.request_context, {"dn": "CN=x"})
+
+    def test_from_operation_exception_capture(self):
+        envelope = ADOperationEnvelope.from_operation(
+            operation_kind="write",
+            exception=ValueError("boom"),
+        )
+
+        self.assertIs(envelope.success, False)
+        self.assertEqual(envelope.exception_type, "ValueError")
+        self.assertEqual(envelope.exception_message, "boom")
+        self.assertEqual(envelope.message, "boom")
+
+    def test_from_operation_explicit_success_overrides_default(self):
+        envelope = ADOperationEnvelope.from_operation(
+            operation_kind="write",
+            success=False,
+            ldap_result="partial",
+        )
+
+        self.assertIs(envelope.success, False)
+
+    def test_to_response_legacy_includes_mirrors(self):
+        envelope = ADOperationEnvelope.from_operation(
+            operation_kind="write",
+            ldap_result={"description": "success"},
+        )
+        payload = envelope.to_response("legacy")
+
+        self.assertIn("result", payload)
+        self.assertIn("message", payload)
+        self.assertEqual(payload["result"], payload["ldap_result"])
+
+    def test_to_response_mixed_includes_mirrors(self):
+        envelope = ADOperationEnvelope.from_operation(operation_kind="write")
+        payload = envelope.to_response("mixed")
+
+        self.assertIn("result", payload)
+        self.assertIn("message", payload)
+
+    def test_to_response_strict_omits_mirrors(self):
+        envelope = ADOperationEnvelope.from_operation(
+            operation_kind="write",
+            ldap_result={"description": "success"},
+        )
+        payload = envelope.to_response("strict")
+
+        self.assertNotIn("result", payload)
+        self.assertNotIn("message", payload)
+        self.assertIn("ldap_result", payload)
+        self.assertIn("success", payload)
+
+    def test_to_response_unknown_mode_falls_back_to_legacy(self):
+        envelope = ADOperationEnvelope.from_operation(operation_kind="write")
+        payload = envelope.to_response("nonsense")
+
+        self.assertIn("result", payload)
+        self.assertIn("message", payload)
 
 
 if __name__ == "__main__":

--- a/src/tests/test_services/test_ad_operation_envelope.py
+++ b/src/tests/test_services/test_ad_operation_envelope.py
@@ -1,0 +1,278 @@
+"""Service-layer contract tests for the AD operation envelope.
+
+Validates that wired write operations across `ADUserService`, `ADGroupService`
+and `ADOrganizationalUnitService` honor the compatibility-mode contract:
+
+- ``legacy`` mode preserves the pre-modernization dict shape unchanged.
+- ``mixed`` mode emits an envelope with legacy mirror keys (``success``,
+  ``result``, ``message``) plus modern envelope fields.
+- ``strict`` mode emits the modern envelope and omits legacy mirror keys.
+- Exception paths populate ``exception_type``/``exception_message``/``message``
+  and set ``success=False``.
+"""
+
+import sys
+from pathlib import Path
+import unittest
+from unittest.mock import MagicMock
+
+from ldap3.core.exceptions import LDAPException
+
+SRC_ROOT = Path(__file__).resolve().parents[2]
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from python_apis.services.ad_user_service import ADUserService
+from python_apis.services.ad_group_service import ADGroupService
+from python_apis.services.ad_ou_service import ADOrganizationalUnitService
+from python_apis.models.ad_user import ADUser
+
+# Modern envelope fields that must be present whenever an envelope is emitted.
+ENVELOPE_FIELDS = (
+    "success",
+    "operation_kind",
+    "ldap_result",
+    "exception_type",
+    "exception_message",
+    "request_context",
+    "retry_count",
+    "retried",
+    "error_code",
+)
+
+
+class TestUserServiceEnvelope(unittest.TestCase):
+    """Envelope contract for `ADUserService.enable_user`."""
+
+    def setUp(self):
+        self.mock_ad_connection = MagicMock()
+        self.mock_sql_connection = MagicMock()
+
+    def _service(self, mode):
+        return ADUserService(
+            ad_connection=self.mock_ad_connection,
+            sql_connection=self.mock_sql_connection,
+            compatibility_mode=mode,
+        )
+
+    def _user(self):
+        user = MagicMock(spec=ADUser)
+        user.distinguishedName = "CN=John,DC=example,DC=com"
+        return user
+
+    def test_legacy_mode_preserves_dict_unchanged(self):
+        service = self._service("legacy")
+        self.mock_ad_connection.enable_user.return_value = {
+            "success": True,
+            "result": "ok",
+        }
+
+        result = service.enable_user(self._user())
+
+        self.assertEqual(result, {"success": True, "result": "ok"})
+
+    def test_mixed_mode_emits_envelope_with_legacy_mirrors(self):
+        service = self._service("mixed")
+        self.mock_ad_connection.enable_user.return_value = {
+            "success": True,
+            "result": "ok",
+        }
+
+        result = service.enable_user(self._user())
+
+        for field in ENVELOPE_FIELDS:
+            self.assertIn(field, result)
+        self.assertEqual(result["operation_kind"], "write")
+        self.assertTrue(result["success"])
+        # Legacy mirrors present and consistent with modern fields.
+        self.assertEqual(result["result"], "ok")
+        self.assertEqual(result["ldap_result"], "ok")
+        self.assertIn("message", result)
+        self.assertEqual(
+            result["request_context"].get("compatibility_mode"), "mixed"
+        )
+
+    def test_strict_mode_omits_legacy_mirror_keys(self):
+        service = self._service("strict")
+        self.mock_ad_connection.enable_user.return_value = {
+            "success": True,
+            "result": "ok",
+        }
+
+        result = service.enable_user(self._user())
+
+        for field in ENVELOPE_FIELDS:
+            self.assertIn(field, result)
+        self.assertNotIn("result", result)
+        self.assertNotIn("message", result)
+        self.assertEqual(result["ldap_result"], "ok")
+
+    def test_per_call_override_beats_service_default(self):
+        service = self._service("legacy")
+        self.mock_ad_connection.enable_user.return_value = {
+            "success": True,
+            "result": "ok",
+        }
+
+        result = service.enable_user(self._user(), compatibility_mode="mixed")
+
+        self.assertEqual(result["operation_kind"], "write")
+        self.assertEqual(result["ldap_result"], "ok")
+
+
+class TestGroupServiceEnvelope(unittest.TestCase):
+    """Envelope contract for `ADGroupService.modify_group`."""
+
+    def setUp(self):
+        self.mock_ad_connection = MagicMock()
+        self.mock_sql_connection = MagicMock()
+
+    def _service(self, mode):
+        return ADGroupService(
+            ad_connection=self.mock_ad_connection,
+            sql_connection=self.mock_sql_connection,
+            compatibility_mode=mode,
+        )
+
+    def _group(self):
+        group = MagicMock()
+        group.distinguishedName = "CN=Team,DC=example,DC=com"
+        group.description = "old"
+        return group
+
+    def test_legacy_mode_preserves_dict_unchanged(self):
+        service = self._service("legacy")
+        self.mock_ad_connection.modify.return_value = {
+            "success": True,
+            "result": "ok",
+        }
+
+        result = service.modify_group(
+            self._group(), [("description", "new")]
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "success": True,
+                "result": "ok",
+                "changes": {"description": "old -> new"},
+            },
+        )
+
+    def test_mixed_mode_preserves_changes_and_mirrors(self):
+        service = self._service("mixed")
+        self.mock_ad_connection.modify.return_value = {
+            "success": True,
+            "result": "ok",
+        }
+
+        result = service.modify_group(
+            self._group(), [("description", "new")]
+        )
+
+        for field in ENVELOPE_FIELDS:
+            self.assertIn(field, result)
+        self.assertEqual(result["changes"], {"description": "old -> new"})
+        self.assertEqual(result["result"], "ok")
+        self.assertEqual(
+            result["request_context"].get("changes"),
+            {"description": "old -> new"},
+        )
+
+    def test_strict_mode_omits_legacy_mirrors_keeps_changes(self):
+        service = self._service("strict")
+        self.mock_ad_connection.modify.return_value = {
+            "success": True,
+            "result": "ok",
+        }
+
+        result = service.modify_group(
+            self._group(), [("description", "new")]
+        )
+
+        self.assertNotIn("result", result)
+        self.assertNotIn("message", result)
+        self.assertEqual(result["changes"], {"description": "old -> new"})
+        self.assertEqual(result["ldap_result"], "ok")
+
+    def test_exception_path_populates_envelope(self):
+        service = self._service("mixed")
+        self.mock_ad_connection.modify.side_effect = LDAPException("boom")
+
+        result = service.modify_group(
+            self._group(), [("description", "new")]
+        )
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["exception_type"], "LDAPException")
+        self.assertEqual(result["exception_message"], "boom")
+        self.assertEqual(result["message"], "boom")
+
+
+class TestOrganizationalUnitServiceEnvelope(unittest.TestCase):
+    """Envelope contract for `ADOrganizationalUnitService.modify_ou`."""
+
+    def setUp(self):
+        self.mock_ad_connection = MagicMock()
+        self.mock_sql_connection = MagicMock()
+
+    def _service(self, mode):
+        return ADOrganizationalUnitService(
+            ad_connection=self.mock_ad_connection,
+            sql_connection=self.mock_sql_connection,
+            compatibility_mode=mode,
+        )
+
+    def _ou(self):
+        ou = MagicMock()
+        ou.distinguishedName = "OU=Team,DC=example,DC=com"
+        ou.description = "old"
+        return ou
+
+    def test_legacy_mode_preserves_dict_unchanged(self):
+        service = self._service("legacy")
+        self.mock_ad_connection.modify.return_value = {
+            "success": True,
+            "result": "ok",
+        }
+
+        result = service.modify_ou(self._ou(), [("description", "new")])
+
+        self.assertEqual(
+            result,
+            {
+                "success": True,
+                "result": "ok",
+                "changes": {"description": "old -> new"},
+            },
+        )
+
+    def test_mixed_mode_preserves_changes_and_mirrors(self):
+        service = self._service("mixed")
+        self.mock_ad_connection.modify.return_value = {
+            "success": True,
+            "result": "ok",
+        }
+
+        result = service.modify_ou(self._ou(), [("description", "new")])
+
+        for field in ENVELOPE_FIELDS:
+            self.assertIn(field, result)
+        self.assertEqual(result["changes"], {"description": "old -> new"})
+        self.assertEqual(result["result"], "ok")
+
+    def test_exception_path_populates_envelope(self):
+        service = self._service("strict")
+        self.mock_ad_connection.modify.side_effect = LDAPException("denied")
+
+        result = service.modify_ou(self._ou(), [("description", "new")])
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["exception_type"], "LDAPException")
+        self.assertEqual(result["exception_message"], "denied")
+        self.assertNotIn("message", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Implements issue #19 (Stage N of the AD response modernization, ADR 0001): a consistent
`ADOperationEnvelope` for AD service **write** operations, built on the dict-compatible response
models from #18. The envelope adds modern, machine-routable metadata while preserving the legacy
dict shape under the default `legacy` compatibility mode, so existing consumers are unaffected.

Compatibility modes drive the output shape:
- `legacy` (default): the historic dict is returned **unchanged** (non-breaking).
- `mixed`: modern envelope fields **plus** legacy mirror keys (`success`/`result`/`message`).
- `strict`: modern envelope only; legacy mirrors omitted.

Forward-compatible fields (`error_code`, `retry_count`, `retried`) ship now with safe defaults so
the envelope shape is stable for #20 (error taxonomy) and #21 (retry telemetry).

## Changes

- **Model**: add `ADOperationEnvelope` to `src/python_apis/models/ad_responses.py` with
  `from_operation(...)` factory (exception capture) and mode-aware `to_response(mode)` mirroring;
  export it from `src/python_apis/models/__init__.py`.
- **Shared helper**: add `finalize_ad_write_response` to
  `src/python_apis/services/compatibility_mode.py` so all three AD services share one
  envelope/legacy-mirroring implementation.
- **Service wiring**: route write ops through the helper with an optional per-call
  `compatibility_mode` override in `ad_user_service.py` (9 write ops), `ad_group_service.py`
  (`modify_group`), and `ad_ou_service.py` (`modify_ou`). Operation extras (`dn`, `changes`, ...)
  preserved top-level and in `request_context`.
- **Tests**: add envelope unit tests in `test_ad_responses.py` and 11 service-layer contract tests
  in `test_ad_operation_envelope.py`.
- **Docs**: add `docs/migration/ad-operation-envelope.md`; update `CHANGELOG.md` (Unreleased).

## Testing

1. Run the suite: `python -m unittest discover -s src/tests -p "test_*.py"` — 126 tests pass.
2. Lint: `pylint src/python_apis/` — 10/10.
3. Manual: call any write op (e.g. `ADGroupService.modify_group`) with `compatibility_mode` of
   `legacy` (dict unchanged), `mixed` (mirrors + modern fields), and `strict` (modern only).

## SemVer

`semver:minor` — additive, non-breaking. `legacy` mode (the default) preserves existing behavior
exactly. Please apply the `semver:minor` label.

Closes #19