### PR TITLE
fix(#19): preserve strict-mode failure details and mirror omission

### DIFF
--- a/src/python_apis/services/ad_user_service.py
+++ b/src/python_apis/services/ad_user_service.py
@@ -571,10 +571,13 @@ class ADUserService:
                 effective_mode=effective_mode,
             )
 
-        # Optional: set password then enable
+        # Optional: set password then enable. Internal sub-operations are pinned
+        # to legacy mode so their `result`/`success` keys are always present for
+        # the partial-failure aggregation below, regardless of the effective mode.
         if set_password:
             pw_resp = self.set_password(
-                dn, set_password, must_change_at_next_logon=must_change_password
+                dn, set_password, must_change_at_next_logon=must_change_password,
+                compatibility_mode='legacy',
             )
             if not pw_resp.get('success'):
                 self.logger.warning("Set password failed for %s: %s", dn, pw_resp.get('result'))
@@ -592,7 +595,7 @@ class ADUserService:
                 )
 
         if enable_after_create:
-            en_resp = self.enable_user(dn)
+            en_resp = self.enable_user(dn, compatibility_mode='legacy')
             if not en_resp.get('success'):
                 self.logger.warning("Enable user failed for %s: %s", dn, en_resp.get('result'))
                 return self._finalize_write(

--- a/src/python_apis/services/compatibility_mode.py
+++ b/src/python_apis/services/compatibility_mode.py
@@ -61,7 +61,7 @@ def finalize_ad_write_response(
     extras = {
         key: value
         for key, value in legacy_response.items()
-        if key not in ("success", "result")
+        if key not in ("success", "result", "message")
     }
     success = (
         False if exception is not None else bool(legacy_response.get("success"))

--- a/src/tests/test_services/test_ad_user_service.py
+++ b/src/tests/test_services/test_ad_user_service.py
@@ -328,6 +328,50 @@ class TestADUserService(unittest.TestCase):
             },
         )
 
+    def test_create_user_password_failure_strict_default_preserves_details(self):
+        # Regression: even when the service default mode is `strict` (which omits
+        # the legacy `result` key), the internal set_password sub-operation must
+        # still surface the LDAP failure details in the aggregated payload.
+        service = ADUserService(compatibility_mode='strict')
+        self.mock_ad_connection.add_entry.return_value = {'success': True, 'result': 'created'}
+        self.mock_ad_connection.set_password.return_value = {'success': False, 'result': 'pw err'}
+
+        result = service.create_user(
+            'John Doe',
+            'OU=Users,DC=example,DC=com',
+            {'sAMAccountName': 'jdoe'},
+            set_password='Sup3rSecure!',
+        )
+
+        self.assertFalse(result['success'])
+        self.assertEqual(
+            result['ldap_result'],
+            {'create': 'created', 'password': 'pw err'},
+        )
+
+    def test_create_user_enable_failure_strict_default_preserves_details(self):
+        # Regression: a `strict` service default must not drop the enable
+        # sub-operation's LDAP failure details from the aggregated payload.
+        service = ADUserService(compatibility_mode='strict')
+        self.mock_ad_connection.add_entry.return_value = {'success': True, 'result': 'created'}
+        self.mock_ad_connection.enable_user.return_value = {
+            'success': False,
+            'result': 'enable err',
+        }
+
+        result = service.create_user(
+            'John Doe',
+            'OU=Users,DC=example,DC=com',
+            {'sAMAccountName': 'jdoe'},
+            enable_after_create=True,
+        )
+
+        self.assertFalse(result['success'])
+        self.assertEqual(
+            result['ldap_result'],
+            {'create': 'created', 'enable': 'enable err'},
+        )
+
     def test_create_user_unexpected_option(self):
         service = ADUserService()
 


### PR DESCRIPTION
## Description

Follow-up to #36, which merged before this review-feedback fix commit was added. PR #36's merge
only included up to the feature commits; this PR cherry-picks the outstanding fix that addresses the
review comments on #36 (strict-mode failure detail loss and a strict-mode mirror leak).

Two issues from the #36 review:

1. **Strict-mode sub-operation failure details dropped.** In `create_user`, the internal
   `set_password`/`enable_user` calls inherited the service default mode. Under a `strict` default,
   `ADOperationEnvelope.to_response("strict")` omits the legacy `result` key, so the aggregated
   partial-failure payload read `None` (`{'password': None}` / `{'enable': None}`) and lost the LDAP
   error. Fixed by pinning those internal sub-operation calls to `legacy` mode so `result`/`success`
   are always present for aggregation.
2. **Strict mode re-added `message`.** `finalize_ad_write_response` included every key except
   `success`/`result` in `extras`, so a legacy `message` key was re-added via `setdefault` in
   `strict` mode, violating the contract that strict omits legacy mirrors. Fixed by also excluding
   `message` from `extras`.

## Changes

- `src/python_apis/services/ad_user_service.py`: pin internal `set_password`/`enable_user` calls in
  `create_user` to `compatibility_mode='legacy'`.
- `src/python_apis/services/compatibility_mode.py`: exclude `message` from `extras` in
  `finalize_ad_write_response`.
- `src/tests/test_services/test_ad_user_service.py`: add two regression tests asserting
  `create_user` surfaces password/enable failure details under a `strict` service default.

## Testing

1. `python -m unittest discover -s src/tests -p "test_*.py"` — 128 tests pass.
2. `pylint src/python_apis/` — 10/10.

## SemVer

`semver:minor` — corrects behavior of the AD operation envelope feature added in #36 (additive,
non-breaking; `legacy` default unchanged). Please apply the `semver:minor` label.

Relates to #19