### PR TITLE
feat(#20): add normalized AD error taxonomy and mapping utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   dict unchanged, `mixed` mirrors legacy keys, `strict` omits them)
 - Service-layer envelope contract tests across user/group/OU write operations
 - Migration guide for the AD operation envelope (`docs/migration/ad-operation-envelope.md`)
+- Normalized AD error taxonomy (`python_apis.services.error_taxonomy`) with eight canonical,
+  transport-agnostic error codes (`AD_NOT_FOUND`, `AD_VALIDATION_ERROR`, `AD_AUTH_ERROR`,
+  `AD_PERMISSION_DENIED`, `AD_CONNECTION_ERROR`, `AD_TIMEOUT`, `AD_CONFLICT`, `AD_UNKNOWN`) and
+  pure mapping utilities (`map_exception_to_error_code`, `map_ldap_result_to_error_code`,
+  `resolve_error_code`) that classify ldap3/`pydantic` exceptions and LDAP result states, with a
+  deterministic `AD_UNKNOWN` fallback
+- Automatic population of `ADOperationEnvelope.error_code` for AD write operations in `mixed`/`strict`
+  compatibility modes (`legacy` responses remain byte-for-byte unchanged; successful ops carry
+  `error_code = None`)
+- Unit tests for the AD error taxonomy and its service-layer integration
 
 ### Fixed
 

--- a/src/python_apis/services/compatibility_mode.py
+++ b/src/python_apis/services/compatibility_mode.py
@@ -13,6 +13,7 @@ from python_apis.apis.ad_api import (
     resolve_ad_compatibility_mode,
 )
 from python_apis.models import ADOperationEnvelope
+from python_apis.services.error_taxonomy import resolve_error_code
 
 ADCompatibilityMode = Literal["legacy", "mixed", "strict"]
 
@@ -66,12 +67,18 @@ def finalize_ad_write_response(
     success = (
         False if exception is not None else bool(legacy_response.get("success"))
     )
+    error_code = resolve_error_code(
+        exception=exception,
+        ldap_result=legacy_response.get("result"),
+        success=success,
+    )
     envelope = ADOperationEnvelope.from_operation(
         operation_kind="write",
         success=success,
         ldap_result=legacy_response.get("result"),
         exception=exception,
         request_context={**extras, "compatibility_mode": effective_mode},
+        error_code=error_code,
     )
     payload = envelope.to_response(effective_mode)
     for key, value in extras.items():

--- a/src/python_apis/services/error_taxonomy.py
+++ b/src/python_apis/services/error_taxonomy.py
@@ -57,6 +57,71 @@ AD_ERROR_CODES: Final[tuple[str, ...]] = (
 )
 
 
+# Maps ldap3 exception / ``pydantic`` error class names to canonical codes. Keyed
+# by class name (rather than imported types) so the mapping is robust to ldap3's
+# large, dynamically generated exception hierarchy without importing every class.
+# Lookup walks the exception's MRO, so subclasses resolve to their nearest mapped
+# ancestor. Names not present here fall through to :data:`AD_UNKNOWN`.
+_EXCEPTION_NAME_TO_CODE: Final[dict[str, str]] = {
+    # Not found
+    "LDAPNoSuchObjectResult": AD_NOT_FOUND,
+    "LDAPNoSuchAttributeResult": AD_NOT_FOUND,
+    # Validation / constraint / schema
+    "ValidationError": AD_VALIDATION_ERROR,
+    "LDAPConstraintViolationResult": AD_VALIDATION_ERROR,
+    "LDAPInvalidAttributeSyntaxResult": AD_VALIDATION_ERROR,
+    "LDAPInvalidDNSyntaxResult": AD_VALIDATION_ERROR,
+    "LDAPNamingViolationResult": AD_VALIDATION_ERROR,
+    "LDAPObjectClassViolationResult": AD_VALIDATION_ERROR,
+    "LDAPUndefinedAttributeTypeResult": AD_VALIDATION_ERROR,
+    "LDAPInvalidValueError": AD_VALIDATION_ERROR,
+    "LDAPAttributeError": AD_VALIDATION_ERROR,
+    # Authentication / bind
+    "LDAPBindError": AD_AUTH_ERROR,
+    "LDAPInvalidCredentialsResult": AD_AUTH_ERROR,
+    "LDAPInappropriateAuthenticationResult": AD_AUTH_ERROR,
+    "LDAPAuthMethodNotSupportedResult": AD_AUTH_ERROR,
+    "LDAPStrongerAuthRequiredResult": AD_AUTH_ERROR,
+    # Permission / authorization
+    "LDAPInsufficientAccessRightsResult": AD_PERMISSION_DENIED,
+    "LDAPAuthorizationDeniedResult": AD_PERMISSION_DENIED,
+    "LDAPConfidentialityRequiredResult": AD_PERMISSION_DENIED,
+    "LDAPUnwillingToPerformResult": AD_PERMISSION_DENIED,
+    # Conflict / already exists
+    "LDAPEntryAlreadyExistsResult": AD_CONFLICT,
+    "LDAPAttributeOrValueExistsResult": AD_CONFLICT,
+    # Timeout
+    "LDAPTimeLimitExceededResult": AD_TIMEOUT,
+    "LDAPResponseTimeoutError": AD_TIMEOUT,
+    # Connection / transport / session
+    "LDAPCommunicationError": AD_CONNECTION_ERROR,
+    "LDAPSessionTerminatedByServerError": AD_CONNECTION_ERROR,
+    "LDAPSocketOpenError": AD_CONNECTION_ERROR,
+    "LDAPSocketSendError": AD_CONNECTION_ERROR,
+    "LDAPSocketReceiveError": AD_CONNECTION_ERROR,
+    "LDAPSocketCloseError": AD_CONNECTION_ERROR,
+    "LDAPServerPoolExhaustedError": AD_CONNECTION_ERROR,
+}
+
+
+def map_exception_to_error_code(exception: BaseException | None) -> str:
+    """Map an exception to a canonical AD error code.
+
+    Resolves ldap3 exceptions and :class:`pydantic.ValidationError` to a stable
+    code by walking the exception's MRO and matching class names against the
+    documented mapping table. Any unmapped or ``None`` exception resolves
+    deterministically to :data:`AD_UNKNOWN`.
+    """
+
+    if exception is None:
+        return AD_UNKNOWN
+    for klass in type(exception).__mro__:
+        code = _EXCEPTION_NAME_TO_CODE.get(klass.__name__)
+        if code is not None:
+            return code
+    return AD_UNKNOWN
+
+
 __all__ = [
     "AD_NOT_FOUND",
     "AD_VALIDATION_ERROR",
@@ -67,4 +132,5 @@ __all__ = [
     "AD_CONFLICT",
     "AD_UNKNOWN",
     "AD_ERROR_CODES",
+    "map_exception_to_error_code",
 ]

--- a/src/python_apis/services/error_taxonomy.py
+++ b/src/python_apis/services/error_taxonomy.py
@@ -184,6 +184,47 @@ def map_ldap_result_to_error_code(result: object) -> str | None:
     return _LDAP_RESULT_CODE_TO_CODE.get(code, AD_UNKNOWN)
 
 
+def resolve_error_code(
+    *,
+    exception: BaseException | None = None,
+    ldap_result: object = None,
+    success: bool | None = None,
+) -> str | None:
+    """Resolve a single canonical error code for an AD operation outcome.
+
+    Resolution order:
+
+    1. If ``exception`` is provided, map it (always yields a failure code).
+    2. Otherwise, if ``success`` is explicitly ``True``, return ``None``.
+    3. Otherwise inspect ``ldap_result``; a success state (``0``) returns
+       ``None``.
+    4. If ``success`` is ``False`` but no specific code was found, fall back to
+       :data:`AD_UNKNOWN`.
+
+    Returns ``None`` when the outcome represents success, otherwise a canonical
+    code string. The function is pure and deterministic.
+    """
+
+    if exception is not None:
+        return map_exception_to_error_code(exception)
+
+    if success is True:
+        return None
+
+    if ldap_result is not None:
+        code = map_ldap_result_to_error_code(ldap_result)
+        if code is not None:
+            return code
+        # ldap_result present but resolved to "no error" (success state).
+        if success is None:
+            return None
+
+    if success is False:
+        return AD_UNKNOWN
+
+    return None
+
+
 __all__ = [
     "AD_NOT_FOUND",
     "AD_VALIDATION_ERROR",
@@ -196,4 +237,5 @@ __all__ = [
     "AD_ERROR_CODES",
     "map_exception_to_error_code",
     "map_ldap_result_to_error_code",
+    "resolve_error_code",
 ]

--- a/src/python_apis/services/error_taxonomy.py
+++ b/src/python_apis/services/error_taxonomy.py
@@ -1,7 +1,7 @@
 """Normalized AD error taxonomy and mapping utilities (ADR 0001, Stage N).
 
 This module defines a small, stable set of canonical error codes for Active
-Directory operations and (in later tasks) utilities that map ldap3 exceptions,
+Directory operations together with utilities that map ldap3 exceptions,
 ``pydantic`` validation errors, and raw LDAP result states onto those codes.
 
 The canonical codes are intentionally transport-agnostic and machine-routable so
@@ -23,9 +23,9 @@ Code                        Meaning
                             insufficientAccessRights).
 ``AD_CONNECTION_ERROR``     Transport/session failure (e.g. communication or
                             session terminated by server).
-``AD_TIMEOUT``             Operation exceeded a time limit / socket timeout.
-``AD_CONFLICT``            Conflicting state (e.g. entryAlreadyExists).
-``AD_UNKNOWN``             Deterministic fallback for any unmapped failure.
+``AD_TIMEOUT``              Operation exceeded a time limit / socket timeout.
+``AD_CONFLICT``             Conflicting state (e.g. entryAlreadyExists).
+``AD_UNKNOWN``              Deterministic fallback for any unmapped failure.
 ==========================  =================================================
 
 Any exception or non-success result state that is not explicitly mapped resolves
@@ -156,32 +156,54 @@ _LDAP_RESULT_CODE_TO_CODE: Final[dict[int, str]] = {
 }
 
 
+def _coerce_ldap_result_code(result: object) -> int | None:
+    """Extract a numeric LDAP result code from a raw code or result mapping.
+
+    Returns the integer code when ``result`` is a plain ``int`` or an ldap3
+    result mapping exposing an integer ``result`` key, otherwise ``None``.
+    ``bool`` is rejected because it is a subclass of ``int``.
+    """
+
+    if isinstance(result, bool):
+        return None
+    if isinstance(result, int):
+        return result
+    if isinstance(result, Mapping):
+        raw = result.get("result")
+        if isinstance(raw, int) and not isinstance(raw, bool):
+            return raw
+    return None
+
+
 def map_ldap_result_to_error_code(result: object) -> str | None:
     """Map an LDAP result state to a canonical AD error code.
 
     Accepts either a raw integer result code or an ldap3 result mapping (which
     exposes the numeric code under a ``result`` key). A success code (``0``)
-    returns ``None`` (no error). Any unrecognized non-zero result state resolves
-    deterministically to :data:`AD_UNKNOWN`. Inputs that carry no usable result
-    code also resolve to :data:`AD_UNKNOWN`.
+    returns ``None`` (no error). Aggregate sub-operation mappings (for example
+    the ``{'create': ..., 'password': ...}`` payloads produced by partial
+    ``create_user`` failures) carry no top-level ``result`` key and are
+    inspected recursively so the first failing sub-operation's canonical code is
+    preserved. Any unrecognized non-zero result state, and any input that
+    carries no usable result code, resolves deterministically to
+    :data:`AD_UNKNOWN`.
     """
 
-    code: int | None = None
-    if isinstance(result, bool):
-        # Guard against bool (a subclass of int) being treated as 0/1 codes.
-        code = None
-    elif isinstance(result, int):
-        code = result
-    elif isinstance(result, Mapping):
-        raw = result.get("result")
-        if isinstance(raw, int) and not isinstance(raw, bool):
-            code = raw
+    code = _coerce_ldap_result_code(result)
+    if code is not None:
+        if code == 0:
+            return None
+        return _LDAP_RESULT_CODE_TO_CODE.get(code, AD_UNKNOWN)
 
-    if code is None:
-        return AD_UNKNOWN
-    if code == 0:
-        return None
-    return _LDAP_RESULT_CODE_TO_CODE.get(code, AD_UNKNOWN)
+    # No direct code: inspect aggregate sub-operation results and surface the
+    # first specific (non-fallback) classification found, if any.
+    if isinstance(result, Mapping):
+        for value in result.values():
+            nested = map_ldap_result_to_error_code(value)
+            if nested is not None and nested != AD_UNKNOWN:
+                return nested
+
+    return AD_UNKNOWN
 
 
 def resolve_error_code(

--- a/src/python_apis/services/error_taxonomy.py
+++ b/src/python_apis/services/error_taxonomy.py
@@ -32,6 +32,7 @@ Any exception or non-success result state that is not explicitly mapped resolves
 to :data:`AD_UNKNOWN`, so the taxonomy is always total over failure inputs.
 """
 
+from collections.abc import Mapping
 from typing import Final
 
 AD_NOT_FOUND: Final = "AD_NOT_FOUND"
@@ -122,6 +123,67 @@ def map_exception_to_error_code(exception: BaseException | None) -> str:
     return AD_UNKNOWN
 
 
+# Maps standard LDAP numeric result codes (RFC 4511 + common extensions) to
+# canonical codes. ``0`` (success) is intentionally absent; success yields no
+# error code. Non-zero result codes not listed here resolve to
+# :data:`AD_UNKNOWN`.
+_LDAP_RESULT_CODE_TO_CODE: Final[dict[int, str]] = {
+    1: AD_UNKNOWN,            # operationsError
+    2: AD_VALIDATION_ERROR,   # protocolError
+    3: AD_TIMEOUT,            # timeLimitExceeded
+    4: AD_VALIDATION_ERROR,   # sizeLimitExceeded
+    7: AD_AUTH_ERROR,         # authMethodNotSupported
+    8: AD_AUTH_ERROR,         # strongerAuthRequired
+    11: AD_PERMISSION_DENIED,  # adminLimitExceeded
+    13: AD_PERMISSION_DENIED,  # confidentialityRequired
+    16: AD_NOT_FOUND,         # noSuchAttribute
+    17: AD_VALIDATION_ERROR,  # undefinedAttributeType
+    18: AD_VALIDATION_ERROR,  # inappropriateMatching
+    19: AD_VALIDATION_ERROR,  # constraintViolation
+    20: AD_CONFLICT,          # attributeOrValueExists
+    21: AD_VALIDATION_ERROR,  # invalidAttributeSyntax
+    32: AD_NOT_FOUND,         # noSuchObject
+    34: AD_VALIDATION_ERROR,  # invalidDNSyntax
+    48: AD_AUTH_ERROR,        # inappropriateAuthentication
+    49: AD_AUTH_ERROR,        # invalidCredentials
+    50: AD_PERMISSION_DENIED,  # insufficientAccessRights
+    51: AD_CONNECTION_ERROR,  # busy
+    52: AD_CONNECTION_ERROR,  # unavailable
+    53: AD_PERMISSION_DENIED,  # unwillingToPerform
+    64: AD_VALIDATION_ERROR,  # namingViolation
+    65: AD_VALIDATION_ERROR,  # objectClassViolation
+    68: AD_CONFLICT,          # entryAlreadyExists
+}
+
+
+def map_ldap_result_to_error_code(result: object) -> str | None:
+    """Map an LDAP result state to a canonical AD error code.
+
+    Accepts either a raw integer result code or an ldap3 result mapping (which
+    exposes the numeric code under a ``result`` key). A success code (``0``)
+    returns ``None`` (no error). Any unrecognized non-zero result state resolves
+    deterministically to :data:`AD_UNKNOWN`. Inputs that carry no usable result
+    code also resolve to :data:`AD_UNKNOWN`.
+    """
+
+    code: int | None = None
+    if isinstance(result, bool):
+        # Guard against bool (a subclass of int) being treated as 0/1 codes.
+        code = None
+    elif isinstance(result, int):
+        code = result
+    elif isinstance(result, Mapping):
+        raw = result.get("result")
+        if isinstance(raw, int) and not isinstance(raw, bool):
+            code = raw
+
+    if code is None:
+        return AD_UNKNOWN
+    if code == 0:
+        return None
+    return _LDAP_RESULT_CODE_TO_CODE.get(code, AD_UNKNOWN)
+
+
 __all__ = [
     "AD_NOT_FOUND",
     "AD_VALIDATION_ERROR",
@@ -133,4 +195,5 @@ __all__ = [
     "AD_UNKNOWN",
     "AD_ERROR_CODES",
     "map_exception_to_error_code",
+    "map_ldap_result_to_error_code",
 ]

--- a/src/python_apis/services/error_taxonomy.py
+++ b/src/python_apis/services/error_taxonomy.py
@@ -1,0 +1,70 @@
+"""Normalized AD error taxonomy and mapping utilities (ADR 0001, Stage N).
+
+This module defines a small, stable set of canonical error codes for Active
+Directory operations and (in later tasks) utilities that map ldap3 exceptions,
+``pydantic`` validation errors, and raw LDAP result states onto those codes.
+
+The canonical codes are intentionally transport-agnostic and machine-routable so
+consumers can branch on a stable string instead of parsing human-readable error
+text. They populate the ``error_code`` field of
+:class:`python_apis.models.ad_responses.ADOperationEnvelope`.
+
+Mapping table (canonical code -> meaning):
+
+==========================  =================================================
+Code                        Meaning
+==========================  =================================================
+``AD_NOT_FOUND``            Target object does not exist (e.g. noSuchObject).
+``AD_VALIDATION_ERROR``     Invalid input/attribute or constraint violation,
+                            including schema/``pydantic`` validation failures.
+``AD_AUTH_ERROR``           Authentication/bind failure (e.g. invalid
+                            credentials).
+``AD_PERMISSION_DENIED``    Caller lacks rights for the operation (e.g.
+                            insufficientAccessRights).
+``AD_CONNECTION_ERROR``     Transport/session failure (e.g. communication or
+                            session terminated by server).
+``AD_TIMEOUT``             Operation exceeded a time limit / socket timeout.
+``AD_CONFLICT``            Conflicting state (e.g. entryAlreadyExists).
+``AD_UNKNOWN``             Deterministic fallback for any unmapped failure.
+==========================  =================================================
+
+Any exception or non-success result state that is not explicitly mapped resolves
+to :data:`AD_UNKNOWN`, so the taxonomy is always total over failure inputs.
+"""
+
+from typing import Final
+
+AD_NOT_FOUND: Final = "AD_NOT_FOUND"
+AD_VALIDATION_ERROR: Final = "AD_VALIDATION_ERROR"
+AD_AUTH_ERROR: Final = "AD_AUTH_ERROR"
+AD_PERMISSION_DENIED: Final = "AD_PERMISSION_DENIED"
+AD_CONNECTION_ERROR: Final = "AD_CONNECTION_ERROR"
+AD_TIMEOUT: Final = "AD_TIMEOUT"
+AD_CONFLICT: Final = "AD_CONFLICT"
+AD_UNKNOWN: Final = "AD_UNKNOWN"
+
+# Ordered, immutable surface of all canonical error codes. ``AD_UNKNOWN`` is the
+# deterministic fallback sentinel and is intentionally listed last.
+AD_ERROR_CODES: Final[tuple[str, ...]] = (
+    AD_NOT_FOUND,
+    AD_VALIDATION_ERROR,
+    AD_AUTH_ERROR,
+    AD_PERMISSION_DENIED,
+    AD_CONNECTION_ERROR,
+    AD_TIMEOUT,
+    AD_CONFLICT,
+    AD_UNKNOWN,
+)
+
+
+__all__ = [
+    "AD_NOT_FOUND",
+    "AD_VALIDATION_ERROR",
+    "AD_AUTH_ERROR",
+    "AD_PERMISSION_DENIED",
+    "AD_CONNECTION_ERROR",
+    "AD_TIMEOUT",
+    "AD_CONFLICT",
+    "AD_UNKNOWN",
+    "AD_ERROR_CODES",
+]

--- a/src/tests/test_services/test_error_taxonomy.py
+++ b/src/tests/test_services/test_error_taxonomy.py
@@ -1,0 +1,233 @@
+"""Tests for the normalized AD error taxonomy and mapping utilities."""
+
+import unittest
+
+from ldap3.core.exceptions import (
+    LDAPCommunicationError,
+    LDAPEntryAlreadyExistsResult,
+    LDAPInsufficientAccessRightsResult,
+    LDAPNoSuchObjectResult,
+)
+from pydantic import BaseModel, ValidationError
+
+from python_apis.services.compatibility_mode import finalize_ad_write_response
+from python_apis.services.error_taxonomy import (
+    AD_AUTH_ERROR,
+    AD_CONFLICT,
+    AD_CONNECTION_ERROR,
+    AD_ERROR_CODES,
+    AD_NOT_FOUND,
+    AD_PERMISSION_DENIED,
+    AD_TIMEOUT,
+    AD_UNKNOWN,
+    AD_VALIDATION_ERROR,
+    map_exception_to_error_code,
+    map_ldap_result_to_error_code,
+    resolve_error_code,
+)
+
+
+class _StrictModel(BaseModel):
+    """Minimal model used to provoke a real ``pydantic`` ValidationError."""
+
+    value: int
+
+
+class _SubclassedNoSuchObject(LDAPNoSuchObjectResult):
+    """Subclass to verify MRO-based resolution to the nearest mapped ancestor."""
+
+
+class TestCanonicalCodes(unittest.TestCase):
+    """Validate the canonical code surface is stable and total."""
+
+    def test_unknown_is_last_sentinel(self):
+        self.assertEqual(AD_ERROR_CODES[-1], AD_UNKNOWN)
+
+    def test_all_codes_unique(self):
+        self.assertEqual(len(set(AD_ERROR_CODES)), len(AD_ERROR_CODES))
+
+    def test_expected_codes_present(self):
+        self.assertEqual(
+            set(AD_ERROR_CODES),
+            {
+                AD_NOT_FOUND,
+                AD_VALIDATION_ERROR,
+                AD_AUTH_ERROR,
+                AD_PERMISSION_DENIED,
+                AD_CONNECTION_ERROR,
+                AD_TIMEOUT,
+                AD_CONFLICT,
+                AD_UNKNOWN,
+            },
+        )
+
+
+class TestMapExceptionToErrorCode(unittest.TestCase):
+    """Validate exception-to-code mapping behavior."""
+
+    def test_none_resolves_to_unknown(self):
+        self.assertEqual(map_exception_to_error_code(None), AD_UNKNOWN)
+
+    def test_pydantic_validation_error_maps_to_validation(self):
+        try:
+            _StrictModel(value="not-an-int")
+        except ValidationError as exc:
+            self.assertEqual(
+                map_exception_to_error_code(exc), AD_VALIDATION_ERROR
+            )
+        else:  # pragma: no cover - guard against silent pass
+            self.fail("expected ValidationError")
+
+    def test_ldap_not_found_maps_by_class_name(self):
+        self.assertEqual(
+            map_exception_to_error_code(LDAPNoSuchObjectResult()),
+            AD_NOT_FOUND,
+        )
+
+    def test_permission_denied_maps_by_class_name(self):
+        self.assertEqual(
+            map_exception_to_error_code(LDAPInsufficientAccessRightsResult()),
+            AD_PERMISSION_DENIED,
+        )
+
+    def test_connection_error_maps_by_class_name(self):
+        self.assertEqual(
+            map_exception_to_error_code(LDAPCommunicationError()),
+            AD_CONNECTION_ERROR,
+        )
+
+    def test_subclass_resolves_via_mro(self):
+        self.assertEqual(
+            map_exception_to_error_code(_SubclassedNoSuchObject()),
+            AD_NOT_FOUND,
+        )
+
+    def test_unmapped_exception_resolves_to_unknown(self):
+        self.assertEqual(
+            map_exception_to_error_code(RuntimeError("boom")), AD_UNKNOWN
+        )
+
+
+class TestMapLDAPResultToErrorCode(unittest.TestCase):
+    """Validate LDAP result-state mapping behavior."""
+
+    def test_success_code_returns_none(self):
+        self.assertIsNone(map_ldap_result_to_error_code(0))
+
+    def test_known_numeric_codes(self):
+        self.assertEqual(map_ldap_result_to_error_code(32), AD_NOT_FOUND)
+        self.assertEqual(map_ldap_result_to_error_code(49), AD_AUTH_ERROR)
+        self.assertEqual(
+            map_ldap_result_to_error_code(50), AD_PERMISSION_DENIED
+        )
+        self.assertEqual(map_ldap_result_to_error_code(68), AD_CONFLICT)
+        self.assertEqual(map_ldap_result_to_error_code(19), AD_VALIDATION_ERROR)
+        self.assertEqual(map_ldap_result_to_error_code(3), AD_TIMEOUT)
+
+    def test_mapping_with_result_key(self):
+        self.assertEqual(
+            map_ldap_result_to_error_code({"result": 32, "description": "x"}),
+            AD_NOT_FOUND,
+        )
+
+    def test_mapping_success_returns_none(self):
+        self.assertIsNone(map_ldap_result_to_error_code({"result": 0}))
+
+    def test_bool_is_not_treated_as_code(self):
+        self.assertEqual(map_ldap_result_to_error_code(True), AD_UNKNOWN)
+        self.assertEqual(map_ldap_result_to_error_code(False), AD_UNKNOWN)
+
+    def test_unrecognized_nonzero_resolves_to_unknown(self):
+        self.assertEqual(map_ldap_result_to_error_code(9999), AD_UNKNOWN)
+
+    def test_unusable_input_resolves_to_unknown(self):
+        self.assertEqual(map_ldap_result_to_error_code("denied"), AD_UNKNOWN)
+        self.assertEqual(map_ldap_result_to_error_code(None), AD_UNKNOWN)
+
+
+class TestResolveErrorCode(unittest.TestCase):
+    """Validate the unified resolver precedence and fallback rules."""
+
+    def test_exception_takes_precedence(self):
+        self.assertEqual(
+            resolve_error_code(
+                exception=LDAPNoSuchObjectResult(),
+                ldap_result=0,
+                success=True,
+            ),
+            AD_NOT_FOUND,
+        )
+
+    def test_explicit_success_returns_none(self):
+        self.assertIsNone(resolve_error_code(success=True))
+        self.assertIsNone(resolve_error_code(success=True, ldap_result=49))
+
+    def test_failure_with_known_result_code(self):
+        self.assertEqual(
+            resolve_error_code(ldap_result=49, success=False), AD_AUTH_ERROR
+        )
+
+    def test_failure_with_unusable_result_falls_back_to_unknown(self):
+        self.assertEqual(
+            resolve_error_code(ldap_result="denied", success=False),
+            AD_UNKNOWN,
+        )
+
+    def test_failure_without_code_falls_back_to_unknown(self):
+        self.assertEqual(resolve_error_code(success=False), AD_UNKNOWN)
+
+    def test_success_result_state_returns_none(self):
+        self.assertIsNone(resolve_error_code(ldap_result=0))
+
+    def test_no_signals_returns_none(self):
+        self.assertIsNone(resolve_error_code())
+
+
+class TestServiceIntegration(unittest.TestCase):
+    """Validate error_code wiring through finalize_ad_write_response."""
+
+    def test_legacy_mode_unchanged(self):
+        legacy = {"success": False, "result": "x"}
+
+        result = finalize_ad_write_response(
+            dict(legacy), effective_mode="legacy"
+        )
+
+        self.assertEqual(result, legacy)
+        self.assertNotIn("error_code", result)
+
+    def test_strict_success_has_none_error_code(self):
+        result = finalize_ad_write_response(
+            {"success": True, "result": "ok"}, effective_mode="strict"
+        )
+
+        self.assertIsNone(result["error_code"])
+
+    def test_mixed_failure_with_exception_populates_error_code(self):
+        result = finalize_ad_write_response(
+            {"success": False, "result": "denied"},
+            effective_mode="mixed",
+            exception=LDAPInsufficientAccessRightsResult(),
+        )
+
+        self.assertEqual(result["error_code"], AD_PERMISSION_DENIED)
+
+    def test_strict_failure_with_result_code_populates_error_code(self):
+        result = finalize_ad_write_response(
+            {"success": False, "result": 49}, effective_mode="strict"
+        )
+
+        self.assertEqual(result["error_code"], AD_AUTH_ERROR)
+
+    def test_conflict_exception_maps_in_mixed_mode(self):
+        result = finalize_ad_write_response(
+            {"success": False, "result": "exists"},
+            effective_mode="mixed",
+            exception=LDAPEntryAlreadyExistsResult(),
+        )
+
+        self.assertEqual(result["error_code"], AD_CONFLICT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_services/test_error_taxonomy.py
+++ b/src/tests/test_services/test_error_taxonomy.py
@@ -144,6 +144,37 @@ class TestMapLDAPResultToErrorCode(unittest.TestCase):
         self.assertEqual(map_ldap_result_to_error_code("denied"), AD_UNKNOWN)
         self.assertEqual(map_ldap_result_to_error_code(None), AD_UNKNOWN)
 
+    def test_aggregate_partial_failure_preserves_subop_code(self):
+        # create_user partial-failure payloads carry no top-level "result" key.
+        self.assertEqual(
+            map_ldap_result_to_error_code(
+                {"create": 0, "password": 49}
+            ),
+            AD_AUTH_ERROR,
+        )
+        self.assertEqual(
+            map_ldap_result_to_error_code(
+                {"create": 0, "enable": 50}
+            ),
+            AD_PERMISSION_DENIED,
+        )
+
+    def test_aggregate_with_nested_result_mapping(self):
+        self.assertEqual(
+            map_ldap_result_to_error_code(
+                {"create": {"result": 0}, "password": {"result": 53}}
+            ),
+            AD_PERMISSION_DENIED,
+        )
+
+    def test_aggregate_without_classifiable_subop_resolves_to_unknown(self):
+        self.assertEqual(
+            map_ldap_result_to_error_code(
+                {"create": "ok", "password": "invalidCredentials"}
+            ),
+            AD_UNKNOWN,
+        )
+
 
 class TestResolveErrorCode(unittest.TestCase):
     """Validate the unified resolver precedence and fallback rules."""
@@ -227,6 +258,19 @@ class TestServiceIntegration(unittest.TestCase):
         )
 
         self.assertEqual(result["error_code"], AD_CONFLICT)
+
+    def test_partial_failure_aggregate_surfaces_subop_code(self):
+        # Mirrors create_user's partial-failure payload (add ok, sub-op failed).
+        result = finalize_ad_write_response(
+            {
+                "success": False,
+                "result": {"create": 0, "password": 49},
+                "dn": "CN=x,OU=y",
+            },
+            effective_mode="strict",
+        )
+
+        self.assertEqual(result["error_code"], AD_AUTH_ERROR)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Adds a normalized, transport-agnostic error taxonomy for Active Directory operations (ADR 0001,
Stage N — additive only). Consumers can now branch on a small, stable set of machine-routable error
codes instead of parsing human-readable LDAP/exception text. The taxonomy is wired into AD write
responses so that `mixed`/`strict` compatibility-mode envelopes surface a populated `error_code`,
while `legacy` responses remain byte-for-byte unchanged.

## Changes

- **New `python_apis.services.error_taxonomy`** module:
  - Eight canonical `Final` error codes: `AD_NOT_FOUND`, `AD_VALIDATION_ERROR`, `AD_AUTH_ERROR`,
    `AD_PERMISSION_DENIED`, `AD_CONNECTION_ERROR`, `AD_TIMEOUT`, `AD_CONFLICT`, `AD_UNKNOWN`
    (sentinel fallback), plus an ordered `AD_ERROR_CODES` tuple.
  - `map_exception_to_error_code(exception)` — maps ldap3 / `pydantic` exceptions by walking the
    MRO and matching class names (avoids importing ldap3's large exception hierarchy).
  - `map_ldap_result_to_error_code(result)` — maps standard LDAP numeric result codes (int or
    ldap3 result mapping); guards `bool`, treats `0` as success (`None`).
  - `resolve_error_code(*, exception, ldap_result, success)` — pure, deterministic resolver with
    exception precedence and `AD_UNKNOWN` fallback.
- **`services/compatibility_mode.py`**: `finalize_ad_write_response` now computes `error_code` via
  `resolve_error_code` and passes it into `ADOperationEnvelope.from_operation(...)`. `legacy` mode
  output is unchanged; successful ops carry `error_code = None`.
- **Tests**: new `src/tests/test_services/test_error_taxonomy.py` (exception mapping, result-state
  mapping, unified resolver, `AD_UNKNOWN` fallback, and service-layer integration across modes).
- **`CHANGELOG.md`**: documented under Unreleased → Added.

## Testing

- `python -m unittest discover -s src/tests -p "test_*.py"` — 157 tests pass.
- `pylint src/python_apis/` — 10.00/10.
- Live integration check: strict success → `error_code = None`; mixed exception →
  `AD_PERMISSION_DENIED`; legacy response unchanged.

## SemVer

`semver:minor` — additive, backward-compatible. `legacy` mode (the default) returns the historic
dict unchanged.

Closes #20