### PR TITLE
feat(#21): add retry metadata and policy telemetry to AD responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   compatibility modes (`legacy` responses remain byte-for-byte unchanged; successful ops carry
   `error_code = None`)
 - Unit tests for the AD error taxonomy and its service-layer integration
+- Retry telemetry and policy metadata on AD responses (issue #21): `ADOperationEnvelope` now carries
+  `would_retry`, `retry_policy`, and a `did_retry` mirror (alongside the existing `retry_count`/
+  `retried`), surfaced in `mixed`/`strict` modes (`legacy` responses remain byte-for-byte unchanged)
+- `RetryTelemetry` dataclass plus `AD_READ_RETRY_POLICY`/`AD_WRITE_RETRY_POLICY` policy constants and
+  `ADConnection.last_retry_telemetry`, capturing per-operation retry outcome (operation kind, attempt
+  count, retried/would-retry/recovered, policy) for the auto-reconnect path (read/write classified)
+- `finalize_ad_read_response` opt-in helper for structured AD read reporting and retry-telemetry
+  threading into AD write finalization across user/group/OU services (default read return types and
+  `legacy` behavior unchanged)
+- Unit tests for AD retry telemetry capture and read/write retry reporting
 
 ### Fixed
 

--- a/src/python_apis/apis/__init__.py
+++ b/src/python_apis/apis/__init__.py
@@ -43,6 +43,9 @@ from python_apis.apis.ad_api import (
     AD_COMPATIBILITY_ENV_VAR,
     AD_COMPATIBILITY_MODES,
     AD_DEFAULT_COMPATIBILITY_MODE,
+    AD_READ_RETRY_POLICY,
+    AD_WRITE_RETRY_POLICY,
+    RetryTelemetry,
     resolve_ad_compatibility_mode,
 )
 from python_apis.apis.jira_api import JiraConnection
@@ -53,6 +56,9 @@ __all__ = [
     "AD_COMPATIBILITY_ENV_VAR",
     "AD_COMPATIBILITY_MODES",
     "AD_DEFAULT_COMPATIBILITY_MODE",
+    "AD_READ_RETRY_POLICY",
+    "AD_WRITE_RETRY_POLICY",
+    "RetryTelemetry",
     "resolve_ad_compatibility_mode",
     "JiraConnection",
     "SQLConnection",

--- a/src/python_apis/apis/ad_api.py
+++ b/src/python_apis/apis/ad_api.py
@@ -151,7 +151,7 @@ def _auto_reconnect(operation_kind: str = "write"):
                     retried=retried,
                     would_retry=would_retry,
                     recovered=recovered,
-                    policy=policy,
+                    policy=dict(policy),
                 )
 
         return wrapper

--- a/src/python_apis/apis/ad_api.py
+++ b/src/python_apis/apis/ad_api.py
@@ -12,6 +12,7 @@ import functools
 import logging
 import os
 import ssl
+from dataclasses import dataclass, field
 from typing import Any
 
 from ldap3.utils.log import set_library_log_detail_level, BASIC
@@ -23,10 +24,55 @@ from ldap3.core.exceptions import LDAPCommunicationError, LDAPSessionTerminatedB
 logger = logging.getLogger(__name__)
 
 _RECOVERABLE_EXCEPTIONS = (LDAPSessionTerminatedByServerError, LDAPCommunicationError)
+_RECOVERABLE_EXCEPTION_NAMES = tuple(exc.__name__ for exc in _RECOVERABLE_EXCEPTIONS)
 
 AD_COMPATIBILITY_MODES = ('legacy', 'mixed', 'strict')
 AD_DEFAULT_COMPATIBILITY_MODE = 'legacy'
 AD_COMPATIBILITY_ENV_VAR = 'PYTHON_APIS_AD_COMPAT_MODE'
+
+
+def _build_retry_policy(operation_kind: str) -> dict[str, Any]:
+    """Describe the current retry policy for a given operation classification.
+
+    The policy is descriptive (not a control knob in Stage N): every decorated
+    AD operation retries at most once after a rebind when a recoverable
+    transport/session error is raised, so reads and writes currently share the
+    same ``rebind_once`` behavior.
+    """
+
+    return {
+        "operation_kind": operation_kind,
+        "max_attempts": 2,
+        "max_retries": 1,
+        "strategy": "rebind_once",
+        "retry_on": _RECOVERABLE_EXCEPTION_NAMES,
+    }
+
+
+AD_READ_RETRY_POLICY = _build_retry_policy("read")
+AD_WRITE_RETRY_POLICY = _build_retry_policy("write")
+_RETRY_POLICY_BY_KIND = {
+    "read": AD_READ_RETRY_POLICY,
+    "write": AD_WRITE_RETRY_POLICY,
+}
+
+
+@dataclass(frozen=True)
+class RetryTelemetry:
+    """Immutable record of the retry outcome for a single AD operation.
+
+    Captured by :func:`_auto_reconnect` on every decorated call and exposed via
+    :attr:`ADConnection.last_retry_telemetry` so service-layer finalizers can
+    surface retry metadata on the operation envelope (issue #21). Recording is
+    observational only and does not alter retry behavior.
+    """
+
+    operation_kind: str
+    retry_count: int = 0
+    retried: bool = False
+    would_retry: bool = False
+    recovered: bool = False
+    policy: dict[str, Any] = field(default_factory=dict)
 
 
 def resolve_ad_compatibility_mode(
@@ -63,23 +109,54 @@ def resolve_ad_compatibility_mode(
     return AD_DEFAULT_COMPATIBILITY_MODE
 
 
-def _auto_reconnect(method):
-    """Decorator that retries the wrapped method once after a rebind
-    when a recoverable LDAP session/communication error is raised."""
+def _auto_reconnect(operation_kind: str = "write"):
+    """Build a decorator that retries once after a rebind on recoverable errors.
 
-    @functools.wraps(method)
-    def wrapper(self, *args, **kwargs):
-        try:
-            return method(self, *args, **kwargs)
-        except _RECOVERABLE_EXCEPTIONS as exc:
-            logger.warning(
-                "LDAP session error in %s, attempting rebind: %s",
-                method.__name__, exc,
-            )
-            self.rebind()
-            return method(self, *args, **kwargs)
+    ``operation_kind`` (``"read"`` or ``"write"``) selects the descriptive retry
+    policy attached to the recorded :class:`RetryTelemetry`. The control flow is
+    unchanged from the historic behavior: the wrapped method is retried at most
+    once after :meth:`ADConnection.rebind` when a recoverable LDAP
+    session/communication error is raised. Telemetry is recorded for every call
+    (including the no-retry success path) on the connection instance.
+    """
 
-    return wrapper
+    policy = _RETRY_POLICY_BY_KIND.get(operation_kind, AD_WRITE_RETRY_POLICY)
+
+    def decorator(method):
+        @functools.wraps(method)
+        def wrapper(self, *args, **kwargs):
+            retry_count = 0
+            retried = False
+            would_retry = False
+            recovered = False
+            try:
+                try:
+                    return method(self, *args, **kwargs)
+                except _RECOVERABLE_EXCEPTIONS as exc:
+                    logger.warning(
+                        "LDAP session error in %s, attempting rebind: %s",
+                        method.__name__, exc,
+                    )
+                    would_retry = True
+                    retried = True
+                    retry_count = 1
+                    self.rebind()
+                    result = method(self, *args, **kwargs)
+                    recovered = True
+                    return result
+            finally:
+                self._last_retry_telemetry = RetryTelemetry(  # pylint: disable=protected-access
+                    operation_kind=operation_kind,
+                    retry_count=retry_count,
+                    retried=retried,
+                    would_retry=would_retry,
+                    recovered=recovered,
+                    policy=policy,
+                )
+
+        return wrapper
+
+    return decorator
 
 
 class ADConnectionError(Exception):
@@ -115,6 +192,18 @@ class ADConnection:
         self.compatibility_mode = resolve_ad_compatibility_mode(service_mode=compatibility_mode)
         self.connection = self._get_connection(servers)
         self.search_base = search_base
+        self._last_retry_telemetry: RetryTelemetry | None = None
+
+    @property
+    def last_retry_telemetry(self) -> RetryTelemetry | None:
+        """Retry telemetry recorded for the most recent decorated AD operation.
+
+        Returns ``None`` until at least one auto-reconnect-wrapped operation has
+        run on this connection. Service-layer finalizers read this immediately
+        after an operation to surface retry metadata on the response envelope.
+        """
+
+        return self._last_retry_telemetry
 
     def _get_connection(self, servers: list) -> Connection:
         """initializes a connection to the active directory.
@@ -181,7 +270,7 @@ class ADConnection:
 
         ad_object['ou'] = ','.join(distinguished_name.split(',')[1:])
 
-    @_auto_reconnect
+    @_auto_reconnect("read")
     def search(
         self, search_filter: str, attributes: list[str] | None = None
     ) -> list[dict[str, str]]:
@@ -219,7 +308,7 @@ class ADConnection:
         search_result = self.search(search_filter, attributes)
         return search_result[0] if len(search_result) > 0 else collections.defaultdict(lambda: '')
 
-    @_auto_reconnect
+    @_auto_reconnect("write")
     def modify(self, distinguished_name: str, changes: list[tuple[str, str]]) -> dict[str, Any]:
         """Takes in distinguished_name and dict of changes.
 
@@ -238,7 +327,7 @@ class ADConnection:
         success = self.connection.modify(distinguished_name, changes)
         return {'result': self.connection.result, 'success': success}
 
-    @_auto_reconnect
+    @_auto_reconnect("write")
     def add_value(self, distinguished_name: str, changes: dict[str, str]) -> dict[str, Any]:
         """Takes in distinguished_name and dict of field and value where the value is added to
         the field specified, this is very useful to add a value to a list.
@@ -258,7 +347,7 @@ class ADConnection:
         success = self.connection.modify(distinguished_name, changes)
         return {'result': self.connection.result, 'success': success}
 
-    @_auto_reconnect
+    @_auto_reconnect("write")
     def remove_value(self, distinguished_name: str, changes: dict[str, str]) -> dict[str, Any]:
         """Takes in distinguished_name and dict of field and value where the specified value is
         removed to the field specified, this is very useful to add a value to a
@@ -309,7 +398,7 @@ class ADConnection:
         changes = {'member': user_dn}
         return self.remove_value(group_dn, changes)
 
-    @_auto_reconnect
+    @_auto_reconnect("write")
     def move_entry(self, distinguished_name: str, new_ou_dn: str) -> dict[str, Any]:
         """Move an AD object to the provided OU while keeping the same relative DN.
 
@@ -329,7 +418,7 @@ class ADConnection:
         )
         return {'result': self.connection.result, 'success': success}
 
-    @_auto_reconnect
+    @_auto_reconnect("write")
     def rename_dn(self, distinguished_name: str, new_relative_dn: str) -> dict[str, Any]:
         """Rename an AD object's relative DN (CN) while keeping it in the same OU.
 
@@ -350,7 +439,7 @@ class ADConnection:
     # ---------------------------------------------------------------------
     # Create new user
     # ---------------------------------------------------------------------
-    @_auto_reconnect
+    @_auto_reconnect("write")
     def add_entry(self, distinguished_name: str, attributes: dict[str, object]) -> dict[str, Any]:
         """Create a new AD object (e.g., user) at the given DN with the provided attributes.
         `attributes` MUST include a valid objectClass list,
@@ -360,7 +449,7 @@ class ADConnection:
         success = self.connection.add(distinguished_name, attributes=attributes)
         return {'result': self.connection.result, 'success': success}
 
-    @_auto_reconnect
+    @_auto_reconnect("write")
     def set_password(self, distinguished_name: str, new_password: str) -> dict[str, Any]:
         """Set the user's password. Requires LDAPS/StartTLS and appropriate rights.
         """
@@ -368,7 +457,7 @@ class ADConnection:
         success = password_ext.modify_password(distinguished_name, new_password)
         return {'result': self.connection.result, 'success': success}
 
-    @_auto_reconnect
+    @_auto_reconnect("write")
     def force_change_password_at_next_logon(
         self, distinguished_name: str, force: bool = True
     ) -> dict[str, Any]:
@@ -389,7 +478,7 @@ class ADConnection:
         success = self.connection.modify(distinguished_name, changes)
         return {'result': self.connection.result, 'success': success}
 
-    @_auto_reconnect
+    @_auto_reconnect("write")
     def enable_user(self, distinguished_name: str) -> dict[str, Any]:
         """Enable an AD user by setting userAccountControl to 512 (NORMAL_ACCOUNT).
         """
@@ -398,7 +487,7 @@ class ADConnection:
         success = self.connection.modify(distinguished_name, changes)
         return {'result': self.connection.result, 'success': success}
 
-    @_auto_reconnect
+    @_auto_reconnect("write")
     def disable_user(self, distinguished_name: str) -> dict[str, Any]:
         """Disable an AD user by setting userAccountControl to 514 (ACCOUNTDISABLE).
         """

--- a/src/python_apis/models/ad_responses.py
+++ b/src/python_apis/models/ad_responses.py
@@ -141,7 +141,9 @@ class ADOperationEnvelope(ADResponse):
     envelope shape stays stable across the rollout:
 
     - ``error_code`` is populated by the normalized error taxonomy (issue #20).
-    - ``retry_count`` / ``retried`` are populated by retry telemetry (issue #21).
+    - ``retry_count`` / ``retried`` / ``would_retry`` / ``retry_policy`` are
+      populated by retry telemetry (issue #21). ``did_retry`` is a legacy-style
+      computed mirror of ``retried``.
     """
 
     success: bool
@@ -152,6 +154,8 @@ class ADOperationEnvelope(ADResponse):
     request_context: dict[str, Any] = Field(default_factory=dict)
     retry_count: int = 0
     retried: bool = False
+    would_retry: bool = False
+    retry_policy: dict[str, Any] | None = None
     error_code: str | None = None
 
     @computed_field
@@ -168,6 +172,13 @@ class ADOperationEnvelope(ADResponse):
 
         return self.exception_message
 
+    @computed_field
+    @property
+    def did_retry(self) -> bool:
+        """Telemetry mirror of :attr:`retried` (issue #21 vocabulary)."""
+
+        return self.retried
+
     @classmethod
     def from_operation(  # pylint: disable=too-many-arguments
         cls,
@@ -179,6 +190,8 @@ class ADOperationEnvelope(ADResponse):
         request_context: dict[str, Any] | None = None,
         retry_count: int = 0,
         retried: bool = False,
+        would_retry: bool = False,
+        retry_policy: dict[str, Any] | None = None,
         error_code: str | None = None,
     ) -> "ADOperationEnvelope":
         """Build an envelope from an AD operation outcome.
@@ -188,9 +201,9 @@ class ADOperationEnvelope(ADResponse):
         are derived from it and ``success`` defaults to ``False``; otherwise
         ``success`` defaults to ``True`` unless explicitly supplied.
 
-        ``retry_count``/``retried``/``error_code`` are accepted now for forward
-        compatibility with retry telemetry (issue #21) and the normalized error
-        taxonomy (issue #20); both currently default to safe values.
+        ``retry_count``/``retried``/``would_retry``/``retry_policy`` carry retry
+        telemetry (issue #21) and ``error_code`` carries the normalized error
+        taxonomy code (issue #20); all default to safe values.
         """
 
         exception_type: str | None = None
@@ -211,6 +224,8 @@ class ADOperationEnvelope(ADResponse):
             request_context=request_context or {},
             retry_count=retry_count,
             retried=retried,
+            would_retry=would_retry,
+            retry_policy=retry_policy,
             error_code=error_code,
         )
 

--- a/src/python_apis/services/ad_group_service.py
+++ b/src/python_apis/services/ad_group_service.py
@@ -238,6 +238,7 @@ class ADGroupService:
                 {'success': False, 'result': str(e)},
                 effective_mode=effective_mode,
                 exception=e,
+                retry_telemetry=self.ad_connection.last_retry_telemetry,
             )
 
         if response is None:
@@ -262,6 +263,7 @@ class ADGroupService:
                 'changes': change_affects,
             },
             effective_mode=effective_mode,
+            retry_telemetry=self.ad_connection.last_retry_telemetry,
         )
 
     @staticmethod

--- a/src/python_apis/services/ad_ou_service.py
+++ b/src/python_apis/services/ad_ou_service.py
@@ -286,6 +286,7 @@ class ADOrganizationalUnitService:
                 {'success': False, 'result': str(e)},
                 effective_mode=effective_mode,
                 exception=e,
+                retry_telemetry=self.ad_connection.last_retry_telemetry,
             )
 
         if response is None:
@@ -310,6 +311,7 @@ class ADOrganizationalUnitService:
                 'changes': change_affects,
             },
             effective_mode=effective_mode,
+            retry_telemetry=self.ad_connection.last_retry_telemetry,
         )
 
     @staticmethod

--- a/src/python_apis/services/ad_user_service.py
+++ b/src/python_apis/services/ad_user_service.py
@@ -81,12 +81,15 @@ class ADUserService:
         Thin wrapper over
         :func:`python_apis.services.compatibility_mode.finalize_ad_write_response`
         so all AD services share one envelope/legacy-mirroring implementation.
+        Retry telemetry captured by the most recent AD operation is surfaced on
+        the envelope.
         """
 
         return finalize_ad_write_response(
             legacy_response,
             effective_mode=effective_mode,
             exception=exception,
+            retry_telemetry=self.ad_connection.last_retry_telemetry,
         )
 
     def get_compatibility_mode(self, compatibility_mode: str | None = None) -> dict[str, str]:

--- a/src/python_apis/services/ad_user_service.py
+++ b/src/python_apis/services/ad_user_service.py
@@ -75,6 +75,7 @@ class ADUserService:
         *,
         effective_mode: str,
         exception: BaseException | None = None,
+        from_ad_operation: bool = True,
     ) -> dict[str, Any]:
         """Shape a write-operation response for the effective compatibility mode.
 
@@ -82,14 +83,19 @@ class ADUserService:
         :func:`python_apis.services.compatibility_mode.finalize_ad_write_response`
         so all AD services share one envelope/legacy-mirroring implementation.
         Retry telemetry captured by the most recent AD operation is surfaced on
-        the envelope.
+        the envelope. For local validation failures that short-circuit before any
+        AD call is made, pass ``from_ad_operation=False`` so stale telemetry from
+        a previous operation is not attributed to this response.
         """
 
+        retry_telemetry = (
+            self.ad_connection.last_retry_telemetry if from_ad_operation else None
+        )
         return finalize_ad_write_response(
             legacy_response,
             effective_mode=effective_mode,
             exception=exception,
-            retry_telemetry=self.ad_connection.last_retry_telemetry,
+            retry_telemetry=retry_telemetry,
         )
 
     def get_compatibility_mode(self, compatibility_mode: str | None = None) -> dict[str, str]:
@@ -638,6 +644,7 @@ class ADUserService:
             return self._finalize_write(
                 {"success": False, "result": "User distinguishedName unavailable"},
                 effective_mode=effective_mode,
+                from_ad_operation=False,
             )
 
         # Extract the current OU from the DN (everything after the first comma)
@@ -646,6 +653,7 @@ class ADUserService:
             return self._finalize_write(
                 {"success": False, "result": "Invalid distinguishedName format"},
                 effective_mode=effective_mode,
+                from_ad_operation=False,
             )
 
         current_ou = dn_parts[1]

--- a/src/python_apis/services/compatibility_mode.py
+++ b/src/python_apis/services/compatibility_mode.py
@@ -10,6 +10,7 @@ from python_apis.apis.ad_api import (
     AD_COMPATIBILITY_ENV_VAR,
     AD_COMPATIBILITY_MODES,
     AD_DEFAULT_COMPATIBILITY_MODE,
+    RetryTelemetry,
     resolve_ad_compatibility_mode,
 )
 from python_apis.models import ADOperationEnvelope
@@ -39,11 +40,29 @@ def resolve_service_compatibility_mode(
     )
 
 
+def _retry_envelope_kwargs(retry_telemetry: RetryTelemetry | None) -> dict[str, Any]:
+    """Translate captured retry telemetry into envelope ``from_operation`` kwargs.
+
+    Returns an empty mapping (safe envelope defaults) when no telemetry is
+    available, so callers can always ``**``-splat the result.
+    """
+
+    if retry_telemetry is None:
+        return {}
+    return {
+        "retry_count": retry_telemetry.retry_count,
+        "retried": retry_telemetry.retried,
+        "would_retry": retry_telemetry.would_retry,
+        "retry_policy": dict(retry_telemetry.policy) if retry_telemetry.policy else None,
+    }
+
+
 def finalize_ad_write_response(
     legacy_response: dict[str, Any],
     *,
     effective_mode: str,
     exception: BaseException | None = None,
+    retry_telemetry: RetryTelemetry | None = None,
 ) -> dict[str, Any]:
     """Shape an AD write-operation response for the effective compatibility mode.
 
@@ -54,6 +73,11 @@ def finalize_ad_write_response(
     while ``strict`` omits them. Operation-specific extras (for example ``dn``
     or ``changes``) are preserved as top-level keys and captured in
     ``request_context``.
+
+    When ``retry_telemetry`` is provided (typically
+    ``ADConnection.last_retry_telemetry`` captured immediately after the
+    operation), its retry counters and policy metadata are surfaced on the
+    envelope; ``legacy`` mode output is unaffected.
     """
 
     if effective_mode == "legacy":
@@ -79,6 +103,7 @@ def finalize_ad_write_response(
         exception=exception,
         request_context={**extras, "compatibility_mode": effective_mode},
         error_code=error_code,
+        **_retry_envelope_kwargs(retry_telemetry),
     )
     payload = envelope.to_response(effective_mode)
     for key, value in extras.items():

--- a/src/python_apis/services/compatibility_mode.py
+++ b/src/python_apis/services/compatibility_mode.py
@@ -111,6 +111,52 @@ def finalize_ad_write_response(
     return payload
 
 
+def finalize_ad_read_response(  # pylint: disable=too-many-arguments
+    read_result: Any,
+    *,
+    effective_mode: str,
+    success: bool | None = None,
+    exception: BaseException | None = None,
+    retry_telemetry: RetryTelemetry | None = None,
+    request_context: dict[str, Any] | None = None,
+) -> Any:
+    """Optionally wrap an AD read outcome in an operation envelope.
+
+    This helper is opt-in: default read service methods keep returning their
+    historic value (for example ``list[ADUser]``). In ``legacy`` mode the raw
+    ``read_result`` is returned unchanged (non-breaking, mirroring
+    :func:`finalize_ad_write_response`). In ``mixed`` and ``strict`` modes an
+    :class:`ADOperationEnvelope` with ``operation_kind="read"`` is built, with
+    ``read_result`` exposed as ``ldap_result`` and any captured
+    ``retry_telemetry`` surfaced as retry metadata.
+
+    ``success`` defaults to ``exception is None`` when not supplied.
+    """
+
+    if effective_mode == "legacy":
+        return read_result
+
+    if success is None:
+        success = exception is None
+    error_code = resolve_error_code(
+        exception=exception,
+        ldap_result=read_result,
+        success=success,
+    )
+    context = dict(request_context or {})
+    context["compatibility_mode"] = effective_mode
+    envelope = ADOperationEnvelope.from_operation(
+        operation_kind="read",
+        success=success,
+        ldap_result=read_result,
+        exception=exception,
+        request_context=context,
+        error_code=error_code,
+        **_retry_envelope_kwargs(retry_telemetry),
+    )
+    return envelope.to_response(effective_mode)
+
+
 __all__ = [
     "ADCompatibilityMode",
     "AD_COMPATIBILITY_MODES",
@@ -118,4 +164,5 @@ __all__ = [
     "AD_COMPATIBILITY_ENV_VAR",
     "resolve_service_compatibility_mode",
     "finalize_ad_write_response",
+    "finalize_ad_read_response",
 ]

--- a/src/tests/test_services/test_retry_telemetry.py
+++ b/src/tests/test_services/test_retry_telemetry.py
@@ -1,0 +1,258 @@
+"""Tests for AD retry telemetry capture and reporting (issue #21)."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ldap3.core.exceptions import (
+    LDAPCommunicationError,
+    LDAPSessionTerminatedByServerError,
+)
+
+from python_apis.apis.ad_api import (
+    ADConnection,
+    AD_READ_RETRY_POLICY,
+    AD_WRITE_RETRY_POLICY,
+    RetryTelemetry,
+)
+from python_apis.models.ad_responses import ADOperationEnvelope
+from python_apis.services.compatibility_mode import (
+    finalize_ad_read_response,
+    finalize_ad_write_response,
+)
+
+
+class TestApiLayerRetryTelemetry(unittest.TestCase):
+    """Validate telemetry recorded by the auto-reconnect decorator."""
+
+    def setUp(self):
+        self.servers = ['ldap://server1', 'ldap://server2']
+        self.search_base = 'dc=example,dc=com'
+
+        patcher = patch('python_apis.apis.ad_api.Connection')
+        self.mock_connection_cls = patcher.start()
+        self.mock_connection = MagicMock()
+        self.mock_connection.bind.return_value = True
+        self.mock_connection_cls.return_value = self.mock_connection
+        self.addCleanup(patcher.stop)
+
+    def test_no_retry_success_records_read_telemetry(self):
+        conn = ADConnection(self.servers, self.search_base)
+        mock_result = [{'attributes': {'cn': 'John Doe'}}]
+        self.mock_connection.extend.standard.paged_search.return_value = iter(mock_result)
+
+        conn.search('(objectClass=user)', ['cn'])
+
+        telemetry = conn.last_retry_telemetry
+        self.assertIsNotNone(telemetry)
+        self.assertEqual(telemetry.operation_kind, 'read')
+        self.assertEqual(telemetry.retry_count, 0)
+        self.assertFalse(telemetry.retried)
+        self.assertFalse(telemetry.would_retry)
+        self.assertFalse(telemetry.recovered)
+        self.assertEqual(telemetry.policy, AD_READ_RETRY_POLICY)
+
+    def test_recover_after_retry_records_write_telemetry(self):
+        conn = ADConnection(self.servers, self.search_base)
+        self.mock_connection.modify.side_effect = [
+            LDAPSessionTerminatedByServerError('boom'),
+            True,
+        ]
+        self.mock_connection.result = {'description': 'success'}
+
+        with patch.object(conn, 'rebind') as mock_rebind:
+            response = conn.modify('CN=x,dc=example,dc=com', [('title', 'Dev')])
+
+        mock_rebind.assert_called_once()
+        self.assertTrue(response['success'])
+        telemetry = conn.last_retry_telemetry
+        self.assertEqual(telemetry.operation_kind, 'write')
+        self.assertEqual(telemetry.retry_count, 1)
+        self.assertTrue(telemetry.retried)
+        self.assertTrue(telemetry.would_retry)
+        self.assertTrue(telemetry.recovered)
+        self.assertEqual(telemetry.policy, AD_WRITE_RETRY_POLICY)
+
+    def test_non_recoverable_exception_propagates_without_retry(self):
+        conn = ADConnection(self.servers, self.search_base)
+        self.mock_connection.modify.side_effect = ValueError('bad input')
+
+        with patch.object(conn, 'rebind') as mock_rebind:
+            with self.assertRaises(ValueError):
+                conn.modify('CN=x,dc=example,dc=com', [('title', 'Dev')])
+
+        mock_rebind.assert_not_called()
+        telemetry = conn.last_retry_telemetry
+        self.assertEqual(telemetry.operation_kind, 'write')
+        self.assertEqual(telemetry.retry_count, 0)
+        self.assertFalse(telemetry.retried)
+        self.assertFalse(telemetry.recovered)
+
+    def test_failed_retry_records_attempt_without_recovery(self):
+        conn = ADConnection(self.servers, self.search_base)
+        self.mock_connection.modify.side_effect = [
+            LDAPCommunicationError('first'),
+            LDAPCommunicationError('second'),
+        ]
+
+        with patch.object(conn, 'rebind') as mock_rebind:
+            with self.assertRaises(LDAPCommunicationError):
+                conn.modify('CN=x,dc=example,dc=com', [('title', 'Dev')])
+
+        mock_rebind.assert_called_once()
+        telemetry = conn.last_retry_telemetry
+        self.assertEqual(telemetry.retry_count, 1)
+        self.assertTrue(telemetry.retried)
+        self.assertTrue(telemetry.would_retry)
+        self.assertFalse(telemetry.recovered)
+
+
+class TestEnvelopeRetryFields(unittest.TestCase):
+    """Validate retry fields surface on the envelope across compatibility modes."""
+
+    def _build_envelope(self):
+        return ADOperationEnvelope.from_operation(
+            operation_kind='write',
+            success=True,
+            ldap_result={'description': 'success'},
+            retry_count=1,
+            retried=True,
+            would_retry=True,
+            retry_policy=AD_WRITE_RETRY_POLICY,
+        )
+
+    def test_retry_fields_present_in_mixed_mode(self):
+        payload = self._build_envelope().to_response('mixed')
+
+        self.assertEqual(payload['retry_count'], 1)
+        self.assertTrue(payload['retried'])
+        self.assertTrue(payload['would_retry'])
+        self.assertTrue(payload['did_retry'])
+        self.assertEqual(payload['retry_policy'], AD_WRITE_RETRY_POLICY)
+
+    def test_retry_fields_present_in_strict_mode(self):
+        payload = self._build_envelope().to_response('strict')
+
+        self.assertEqual(payload['retry_count'], 1)
+        self.assertTrue(payload['did_retry'])
+        self.assertEqual(payload['retry_policy'], AD_WRITE_RETRY_POLICY)
+        self.assertNotIn('result', payload)
+        self.assertNotIn('message', payload)
+
+    def test_did_retry_mirrors_retried(self):
+        envelope = ADOperationEnvelope.from_operation(
+            operation_kind='read',
+            success=True,
+            retried=False,
+        )
+
+        self.assertFalse(envelope.did_retry)
+
+
+class TestWriteResponseRetryIntegration(unittest.TestCase):
+    """Validate finalize_ad_write_response threads retry telemetry."""
+
+    def setUp(self):
+        self.telemetry = RetryTelemetry(
+            operation_kind='write',
+            retry_count=1,
+            retried=True,
+            would_retry=True,
+            recovered=True,
+            policy=AD_WRITE_RETRY_POLICY,
+        )
+
+    def test_legacy_mode_ignores_telemetry(self):
+        legacy = {'success': True, 'result': 'ok'}
+
+        payload = finalize_ad_write_response(
+            legacy,
+            effective_mode='legacy',
+            retry_telemetry=self.telemetry,
+        )
+
+        self.assertEqual(payload, legacy)
+
+    def test_mixed_mode_includes_telemetry(self):
+        payload = finalize_ad_write_response(
+            {'success': True, 'result': 'ok'},
+            effective_mode='mixed',
+            retry_telemetry=self.telemetry,
+        )
+
+        self.assertEqual(payload['retry_count'], 1)
+        self.assertTrue(payload['did_retry'])
+        self.assertEqual(payload['retry_policy']['strategy'], 'rebind_once')
+
+    def test_absent_telemetry_yields_defaults(self):
+        payload = finalize_ad_write_response(
+            {'success': True, 'result': 'ok'},
+            effective_mode='mixed',
+        )
+
+        self.assertEqual(payload['retry_count'], 0)
+        self.assertFalse(payload['retried'])
+        self.assertFalse(payload['would_retry'])
+        self.assertIsNone(payload['retry_policy'])
+
+
+class TestReadResponseRetryIntegration(unittest.TestCase):
+    """Validate finalize_ad_read_response builds opt-in read envelopes."""
+
+    def setUp(self):
+        self.telemetry = RetryTelemetry(
+            operation_kind='read',
+            retry_count=1,
+            retried=True,
+            would_retry=True,
+            recovered=True,
+            policy=AD_READ_RETRY_POLICY,
+        )
+
+    def test_legacy_mode_returns_raw_result(self):
+        result = ['a', 'b']
+
+        returned = finalize_ad_read_response(
+            result,
+            effective_mode='legacy',
+            retry_telemetry=self.telemetry,
+        )
+
+        self.assertIs(returned, result)
+
+    def test_mixed_mode_builds_read_envelope(self):
+        payload = finalize_ad_read_response(
+            ['a', 'b'],
+            effective_mode='mixed',
+            retry_telemetry=self.telemetry,
+        )
+
+        self.assertEqual(payload['operation_kind'], 'read')
+        self.assertEqual(payload['result'], ['a', 'b'])
+        self.assertEqual(payload['retry_count'], 1)
+        self.assertTrue(payload['did_retry'])
+        self.assertEqual(payload['retry_policy'], AD_READ_RETRY_POLICY)
+
+    def test_strict_mode_omits_legacy_mirrors(self):
+        payload = finalize_ad_read_response(
+            ['a', 'b'],
+            effective_mode='strict',
+        )
+
+        self.assertEqual(payload['operation_kind'], 'read')
+        self.assertNotIn('result', payload)
+        self.assertNotIn('message', payload)
+        self.assertEqual(payload['retry_count'], 0)
+
+    def test_failure_defaults_success_from_exception(self):
+        payload = finalize_ad_read_response(
+            [],
+            effective_mode='mixed',
+            exception=LDAPCommunicationError('down'),
+        )
+
+        self.assertFalse(payload['success'])
+        self.assertEqual(payload['exception_type'], 'LDAPCommunicationError')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/test_services/test_retry_telemetry.py
+++ b/src/tests/test_services/test_retry_telemetry.py
@@ -1,6 +1,7 @@
 """Tests for AD retry telemetry capture and reporting (issue #21)."""
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from ldap3.core.exceptions import (
@@ -15,6 +16,7 @@ from python_apis.apis.ad_api import (
     RetryTelemetry,
 )
 from python_apis.models.ad_responses import ADOperationEnvelope
+from python_apis.services.ad_user_service import ADUserService
 from python_apis.services.compatibility_mode import (
     finalize_ad_read_response,
     finalize_ad_write_response,
@@ -104,6 +106,17 @@ class TestApiLayerRetryTelemetry(unittest.TestCase):
         self.assertTrue(telemetry.retried)
         self.assertTrue(telemetry.would_retry)
         self.assertFalse(telemetry.recovered)
+
+    def test_telemetry_policy_is_isolated_from_global(self):
+        conn = ADConnection(self.servers, self.search_base)
+        self.mock_connection.extend.standard.paged_search.return_value = iter([])
+
+        conn.search('(objectClass=user)', ['cn'])
+
+        telemetry = conn.last_retry_telemetry
+        telemetry.policy['strategy'] = 'mutated'
+        self.assertEqual(AD_READ_RETRY_POLICY['strategy'], 'rebind_once')
+
 
 
 class TestEnvelopeRetryFields(unittest.TestCase):
@@ -252,6 +265,71 @@ class TestReadResponseRetryIntegration(unittest.TestCase):
 
         self.assertFalse(payload['success'])
         self.assertEqual(payload['exception_type'], 'LDAPCommunicationError')
+
+
+class TestLocalValidationTelemetrySuppression(unittest.TestCase):
+    """Local validation failures must not attribute stale retry telemetry."""
+
+    def setUp(self):
+        env_vars = {
+            'ADUSER_DB_SERVER': 'test_server',
+            'ADUSER_DB_NAME': 'test_db',
+            'ADUSER_SQL_DRIVER': 'test_driver',
+            'LDAP_SERVER_LIST': 'ldap://server1 ldap://server2',
+            'SEARCH_BASE': 'dc=example,dc=com',
+        }
+        patcher_getenv = patch('os.getenv', side_effect=lambda k, d=None: env_vars.get(k, d))
+        patcher_getenv.start()
+        self.addCleanup(patcher_getenv.stop)
+
+        self.mock_ad_connection = MagicMock()
+        # Simulate a previous retried write leaving stale telemetry on the connection.
+        self.mock_ad_connection.last_retry_telemetry = RetryTelemetry(
+            operation_kind='write',
+            retry_count=1,
+            retried=True,
+            would_retry=True,
+            recovered=True,
+            policy=AD_WRITE_RETRY_POLICY,
+        )
+        self.mock_sql_connection = MagicMock()
+
+        patcher_ad = patch(
+            'python_apis.services.ad_user_service.ADConnection',
+            return_value=self.mock_ad_connection,
+        )
+        patcher_sql = patch(
+            'python_apis.services.ad_user_service.SQLConnection',
+            return_value=self.mock_sql_connection,
+        )
+        patcher_ad.start()
+        patcher_sql.start()
+        self.addCleanup(patcher_ad.stop)
+        self.addCleanup(patcher_sql.stop)
+
+        self.service = ADUserService()
+
+    def test_rename_missing_dn_does_not_report_stale_retry(self):
+        user = SimpleNamespace(distinguishedName=None)
+
+        payload = self.service.rename_user_cn(user, 'NewName', compatibility_mode='mixed')
+
+        self.assertFalse(payload['success'])
+        self.assertEqual(payload['retry_count'], 0)
+        self.assertFalse(payload['did_retry'])
+        self.assertIsNone(payload['retry_policy'])
+        self.mock_ad_connection.rename_dn.assert_not_called()
+
+    def test_rename_invalid_dn_does_not_report_stale_retry(self):
+        user = SimpleNamespace(distinguishedName='CN=NoComma')
+
+        payload = self.service.rename_user_cn(user, 'NewName', compatibility_mode='strict')
+
+        self.assertFalse(payload['success'])
+        self.assertEqual(payload['retry_count'], 0)
+        self.assertFalse(payload['did_retry'])
+        self.assertIsNone(payload['retry_policy'])
+        self.mock_ad_connection.rename_dn.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

Surfaces auto-reconnect retry behavior as structured, observable metadata on AD responses (issue #21). Previously the `ADConnection` auto-reconnect path retried recoverable LDAP session/communication errors silently, with no way for callers to see whether a retry occurred, what policy governed it, or the outcome. This change captures per-operation retry telemetry at the API layer and threads it into the response envelope for AD write and (opt-in) read operations.

The change is **purely additive and observational** — no retry behavior is changed, and `legacy` compatibility mode responses remain byte-for-byte unchanged.

## Changes

- **Envelope fields** (`models/ad_responses.py`): `ADOperationEnvelope` gains `would_retry`, `retry_policy`, and a `did_retry` computed mirror (alongside existing `retry_count`/`retried`). Surfaced in `mixed`/`strict` modes; `strict` still omits only `result`/`message`.
- **API-layer capture** (`apis/ad_api.py`): new `RetryTelemetry` dataclass, `AD_READ_RETRY_POLICY`/`AD_WRITE_RETRY_POLICY` policy constants, and `ADConnection.last_retry_telemetry`. The `_auto_reconnect` decorator is now a factory parameterized by `operation_kind` (`read`/`write`) and records telemetry for every call (no-retry success, recover-after-retry, failed retry, non-recoverable) via `try/finally`.
- **Write threading** (`services/compatibility_mode.py`, `ad_user_service.py`, `ad_group_service.py`, `ad_ou_service.py`): `finalize_ad_write_response` accepts optional `retry_telemetry` and surfaces retry metadata via a shared `_retry_envelope_kwargs` helper; services pass `ad_connection.last_retry_telemetry`.
- **Opt-in read helper** (`services/compatibility_mode.py`): new `finalize_ad_read_response` builds a `read` envelope in `mixed`/`strict` and returns the raw result in `legacy`. Default read method signatures/returns are unchanged.
- **Exports** (`apis/__init__.py`): `RetryTelemetry`, `AD_READ_RETRY_POLICY`, `AD_WRITE_RETRY_POLICY`.
- **Tests** (`tests/test_services/test_retry_telemetry.py`): 14 new tests for API-layer capture, envelope fields across modes, and read/write integration.
- **CHANGELOG.md**: documented under Unreleased → Added.

## Testing

- `python -m unittest discover -s src/tests -p "test_*.py"` — 175 tests pass.
- `pylint src/python_apis/` — 10.00/10.
- Smoke-tested write/read finalization in `legacy` (unchanged), `mixed`, and `strict` modes.

SemVer: **semver:minor** (additive, backward-compatible; `legacy` mode unchanged).

Closes #21