### PR TITLE
feat(#22): add membership APIs get_user_direct_groups and resolve_primary_group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   threading into AD write finalization across user/group/OU services (default read return types and
   `legacy` behavior unchanged)
 - Unit tests for AD retry telemetry capture and read/write retry reporting
+- Membership APIs v2 on `ADGroupService` (issue #22): `get_user_direct_groups(user)` returning the
+  user's direct group memberships (`list[ADGroup]` via `(&(objectClass=group)(member=<userDN>))`) and
+  `resolve_primary_group(user)` resolving the user's primary group (`ADGroup | None` via the group
+  `primaryGroupToken` constructed attribute), returning `None` gracefully when the user has no
+  `primaryGroupID`; both accept an `ADUser` or string, escape LDAP filter values, and reuse the
+  retry-capable read path (additive, backward-compatible)
+- Contract tests for the membership APIs covering happy and edge paths
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Unit tests for AD retry telemetry capture and read/write retry reporting
 - Membership APIs v2 on `ADGroupService` (issue #22): `get_user_direct_groups(user)` returning the
   user's direct group memberships (`list[ADGroup]` via `(&(objectClass=group)(member=<userDN>))`) and
-  `resolve_primary_group(user)` resolving the user's primary group (`ADGroup | None` via the group
-  `primaryGroupToken` constructed attribute), returning `None` gracefully when the user has no
-  `primaryGroupID`; both accept an `ADUser` or string, escape LDAP filter values, and reuse the
-  retry-capable read path (additive, backward-compatible)
+  `resolve_primary_group(user)` resolving the user's primary group (`ADGroup | None`). Because
+  `primaryGroupToken` is a constructed attribute that cannot be used in an LDAP search filter, the
+  primary group SID is derived from the user's `objectSid` (domain portion) plus `primaryGroupID`
+  (RID) and looked up via `(&(objectClass=group)(objectSid=<sid>))`, returning `None` gracefully when
+  the user has no `objectSid`/`primaryGroupID`. `get_user_direct_groups` accepts an `ADUser` or
+  distinguishedName string; both escape LDAP filter values and reuse the retry-capable read path
+  (additive, backward-compatible)
 - Contract tests for the membership APIs covering happy and edge paths
 
 ### Fixed

--- a/src/python_apis/services/ad_group_service.py
+++ b/src/python_apis/services/ad_group_service.py
@@ -174,27 +174,7 @@ class ADGroupService:
         effective_mode = self._resolve_effective_mode(compatibility_mode)
         self.logger.debug("Using AD compatibility mode '%s' for get_groups_from_ad", effective_mode)
 
-        attributes = ADGroup.get_attribute_list()
-        ad_groups_dict = self.ad_connection.search(search_filter, attributes)
-        ad_groups = []
-
-        for group_data in ad_groups_dict:
-            try:
-                self.set_group_type_name(group_data)
-                # Validate and parse data using Pydantic model
-                validated_data = ADGroupSchema(**group_data).model_dump()
-                # Create ADGroup instance
-                ad_group = ADGroup(**validated_data)
-                ad_groups.append(ad_group)
-            except ValidationError as e:
-                # Handle validation errors
-                self.logger.error(
-                    "Validation error for group %s: %s",
-                    group_data.get('distinguishedName'),
-                    e
-                )
-
-        return ad_groups
+        return self._groups_from_search(search_filter)
 
     def _groups_from_search(self, search_filter: str) -> list[ADGroup]:
         """Run a group search and build validated ``ADGroup`` instances.
@@ -257,27 +237,46 @@ class ADGroupService:
         search_filter = f"(&(objectClass=group)(member={escaped_dn}))"
         return self._groups_from_search(search_filter)
 
+    @staticmethod
+    def _derive_primary_group_sid(user_sid: str, primary_group_id: str) -> str | None:
+        """Derive a primary group's SID from the user's SID and primary group RID.
+
+        A user's primary group is not exposed via ``member``/``memberOf``. Its
+        SID shares the domain portion of the user's ``objectSid`` with the RID
+        replaced by ``primaryGroupID``. For example, user SID
+        ``S-1-5-21-A-B-C-1105`` with ``primaryGroupID=513`` yields the group SID
+        ``S-1-5-21-A-B-C-513``. Returns ``None`` when the user SID has no
+        derivable domain portion.
+        """
+
+        if not user_sid or '-' not in user_sid:
+            return None
+        domain_sid = user_sid.rsplit('-', 1)[0]
+        return f"{domain_sid}-{primary_group_id}"
+
     def resolve_primary_group(
         self,
-        user: ADUser | str,
+        user: ADUser,
         compatibility_mode: str | None = None,
     ) -> ADGroup | None:
         """Resolve a user's primary group.
 
-        A user's primary group is identified by ``primaryGroupID`` (a RID), which
-        is not surfaced through the ``member``/``memberOf`` linkage. This resolves
-        it against the group constructed attribute ``primaryGroupToken`` (equal to
-        the group's RID).
+        A user's primary group is identified by ``primaryGroupID`` (a RID) and is
+        not surfaced through the ``member``/``memberOf`` linkage. Because
+        ``primaryGroupToken`` is a constructed attribute that cannot be evaluated
+        in an LDAP search filter, the primary group's SID is derived from the
+        user's ``objectSid`` (domain portion) and ``primaryGroupID`` (RID), then
+        looked up via ``(&(objectClass=group)(objectSid=<sid>))``.
 
         Args:
-            user (ADUser | str): The user (its ``primaryGroupID`` is read), or the
-                ``primaryGroupID``/RID value directly.
+            user (ADUser): The user whose ``objectSid`` and ``primaryGroupID`` are
+                used to derive the primary group SID.
             compatibility_mode (str | None): Optional per-call compatibility mode
                 override (accepted for API symmetry; reads return typed models).
 
         Returns:
-            ADGroup | None: The primary group, or ``None`` when the user has no
-            ``primaryGroupID`` or no group matches.
+            ADGroup | None: The primary group, or ``None`` when the user is
+            missing ``objectSid``/``primaryGroupID`` or no group matches.
         """
 
         effective_mode = self._resolve_effective_mode(compatibility_mode)
@@ -285,16 +284,24 @@ class ADGroupService:
             "Using AD compatibility mode '%s' for resolve_primary_group", effective_mode
         )
 
-        primary_group_id = user.primaryGroupID if isinstance(user, ADUser) else user
-        if not primary_group_id:
-            self.logger.warning(
-                "Cannot resolve primary group: user has no primaryGroupID (%s)",
+        user_sid = getattr(user, 'objectSid', None)
+        primary_group_id = getattr(user, 'primaryGroupID', None)
+        if not user_sid or not primary_group_id:
+            self.logger.debug(
+                "Cannot resolve primary group: missing objectSid/primaryGroupID (%s)",
                 getattr(user, 'distinguishedName', user),
             )
             return None
 
-        escaped_id = escape_filter_chars(str(primary_group_id))
-        search_filter = f"(&(objectClass=group)(primaryGroupToken={escaped_id}))"
+        group_sid = self._derive_primary_group_sid(str(user_sid), str(primary_group_id))
+        if not group_sid:
+            self.logger.debug(
+                "Cannot derive primary group SID from user objectSid '%s'", user_sid
+            )
+            return None
+
+        escaped_sid = escape_filter_chars(group_sid)
+        search_filter = f"(&(objectClass=group)(objectSid={escaped_sid}))"
         groups = self._groups_from_search(search_filter)
         return groups[0] if groups else None
 

--- a/src/python_apis/services/ad_group_service.py
+++ b/src/python_apis/services/ad_group_service.py
@@ -9,11 +9,12 @@ import os
 from typing import Any
 
 from ldap3.core.exceptions import LDAPException
+from ldap3.utils.conv import escape_filter_chars
 from pydantic import ValidationError
 
 from dev_tools import timing_decorator
 from python_apis.apis import ADConnection, SQLConnection
-from python_apis.models import ADGroup, base
+from python_apis.models import ADGroup, ADUser, base
 from python_apis.schemas import ADGroupSchema
 from python_apis.services.compatibility_mode import (
     finalize_ad_write_response,
@@ -194,6 +195,67 @@ class ADGroupService:
                 )
 
         return ad_groups
+
+    def _groups_from_search(self, search_filter: str) -> list[ADGroup]:
+        """Run a group search and build validated ``ADGroup`` instances.
+
+        Shared read path for group lookups: fetches via ``ad_connection.search``
+        (which retries once on recoverable transport errors), annotates the
+        group-type name, validates each record with ``ADGroupSchema``, and skips
+        (logging) any record that fails validation rather than dropping silently.
+        """
+
+        attributes = ADGroup.get_attribute_list()
+        ad_groups_dict = self.ad_connection.search(search_filter, attributes)
+        ad_groups = []
+
+        for group_data in ad_groups_dict:
+            try:
+                self.set_group_type_name(group_data)
+                validated_data = ADGroupSchema(**group_data).model_dump()
+                ad_groups.append(ADGroup(**validated_data))
+            except ValidationError as e:
+                self.logger.error(
+                    "Validation error for group %s: %s",
+                    group_data.get('distinguishedName'),
+                    e,
+                )
+
+        return ad_groups
+
+    def get_user_direct_groups(
+        self,
+        user: ADUser | str,
+        compatibility_mode: str | None = None,
+    ) -> list[ADGroup]:
+        """Return the groups a user is a direct member of.
+
+        Resolves the groups whose ``member`` attribute contains the user's
+        distinguished name, i.e. direct (non-nested) memberships. Note that AD's
+        ``member``/``memberOf`` linkage does not include a user's *primary*
+        group; use :meth:`resolve_primary_group` for that.
+
+        Args:
+            user (ADUser | str): The user, or the user's distinguishedName.
+            compatibility_mode (str | None): Optional per-call compatibility mode
+                override (accepted for API symmetry; reads return typed models).
+
+        Returns:
+            list[ADGroup]: Direct group memberships (empty list if none).
+        """
+
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
+        self.logger.debug(
+            "Using AD compatibility mode '%s' for get_user_direct_groups", effective_mode
+        )
+
+        user_dn = user.distinguishedName if isinstance(user, ADUser) else user
+        if not user_dn:
+            return []
+
+        escaped_dn = escape_filter_chars(str(user_dn))
+        search_filter = f"(&(objectClass=group)(member={escaped_dn}))"
+        return self._groups_from_search(search_filter)
 
     def modify_group(
         self,

--- a/src/python_apis/services/ad_group_service.py
+++ b/src/python_apis/services/ad_group_service.py
@@ -257,6 +257,47 @@ class ADGroupService:
         search_filter = f"(&(objectClass=group)(member={escaped_dn}))"
         return self._groups_from_search(search_filter)
 
+    def resolve_primary_group(
+        self,
+        user: ADUser | str,
+        compatibility_mode: str | None = None,
+    ) -> ADGroup | None:
+        """Resolve a user's primary group.
+
+        A user's primary group is identified by ``primaryGroupID`` (a RID), which
+        is not surfaced through the ``member``/``memberOf`` linkage. This resolves
+        it against the group constructed attribute ``primaryGroupToken`` (equal to
+        the group's RID).
+
+        Args:
+            user (ADUser | str): The user (its ``primaryGroupID`` is read), or the
+                ``primaryGroupID``/RID value directly.
+            compatibility_mode (str | None): Optional per-call compatibility mode
+                override (accepted for API symmetry; reads return typed models).
+
+        Returns:
+            ADGroup | None: The primary group, or ``None`` when the user has no
+            ``primaryGroupID`` or no group matches.
+        """
+
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
+        self.logger.debug(
+            "Using AD compatibility mode '%s' for resolve_primary_group", effective_mode
+        )
+
+        primary_group_id = user.primaryGroupID if isinstance(user, ADUser) else user
+        if not primary_group_id:
+            self.logger.warning(
+                "Cannot resolve primary group: user has no primaryGroupID (%s)",
+                getattr(user, 'distinguishedName', user),
+            )
+            return None
+
+        escaped_id = escape_filter_chars(str(primary_group_id))
+        search_filter = f"(&(objectClass=group)(primaryGroupToken={escaped_id}))"
+        groups = self._groups_from_search(search_filter)
+        return groups[0] if groups else None
+
     def modify_group(
         self,
         group: ADGroup,

--- a/src/tests/test_services/test_membership_apis.py
+++ b/src/tests/test_services/test_membership_apis.py
@@ -106,6 +106,7 @@ class TestMembershipAPIs(unittest.TestCase):
         ]
         user = ADUser(
             distinguishedName='CN=John,DC=example,DC=com',
+            objectSid='S-1-5-21-1-2-3-1105',
             primaryGroupID='513',
         )
 
@@ -114,34 +115,58 @@ class TestMembershipAPIs(unittest.TestCase):
         self.assertIsInstance(group, ADGroup)
         self.assertEqual(group.name, 'Domain Users')
         search_filter = self.mock_ad_connection.search.call_args[0][0]
+        # primaryGroupToken is a constructed attribute and cannot be filtered;
+        # the group SID is derived from the user's objectSid + primaryGroupID.
         self.assertEqual(
             search_filter,
-            '(&(objectClass=group)(primaryGroupToken=513))',
+            '(&(objectClass=group)(objectSid=S-1-5-21-1-2-3-513))',
         )
 
-    def test_primary_group_accepts_rid_string(self):
-        self.mock_ad_connection.search.return_value = [
-            _group_dict('CN=Domain Users,DC=example,DC=com', 'Domain Users'),
-        ]
-
-        group = self.service.resolve_primary_group('513')
-
-        self.assertIsInstance(group, ADGroup)
-        search_filter = self.mock_ad_connection.search.call_args[0][0]
-        self.assertIn('(primaryGroupToken=513)', search_filter)
-
     def test_primary_group_missing_id_returns_none_without_search(self):
-        user = ADUser(distinguishedName='CN=John,DC=example,DC=com', primaryGroupID=None)
+        user = ADUser(
+            distinguishedName='CN=John,DC=example,DC=com',
+            objectSid='S-1-5-21-1-2-3-1105',
+            primaryGroupID=None,
+        )
 
         group = self.service.resolve_primary_group(user)
 
         self.assertIsNone(group)
         self.mock_ad_connection.search.assert_not_called()
 
+    def test_primary_group_missing_object_sid_returns_none_without_search(self):
+        user = ADUser(
+            distinguishedName='CN=John,DC=example,DC=com',
+            objectSid=None,
+            primaryGroupID='513',
+        )
+
+        group = self.service.resolve_primary_group(user)
+
+        self.assertIsNone(group)
+        self.mock_ad_connection.search.assert_not_called()
+
+    def test_primary_group_escapes_filter_value(self):
+        self.mock_ad_connection.search.return_value = []
+        user = ADUser(
+            distinguishedName='CN=John,DC=example,DC=com',
+            objectSid='S-1-5-21-a(b)*-1105',
+            primaryGroupID='513',
+        )
+
+        self.service.resolve_primary_group(user)
+
+        search_filter = self.mock_ad_connection.search.call_args[0][0]
+        # Derived SID values must be escaped to prevent LDAP filter injection.
+        self.assertIn(r'\28', search_filter)  # (
+        self.assertIn(r'\29', search_filter)  # )
+        self.assertIn(r'\2a', search_filter)  # *
+
     def test_primary_group_no_match_returns_none(self):
         self.mock_ad_connection.search.return_value = []
         user = ADUser(
             distinguishedName='CN=John,DC=example,DC=com',
+            objectSid='S-1-5-21-1-2-3-1105',
             primaryGroupID='999',
         )
 

--- a/src/tests/test_services/test_membership_apis.py
+++ b/src/tests/test_services/test_membership_apis.py
@@ -1,0 +1,154 @@
+"""Contract tests for AD membership APIs (issue #22).
+
+Covers ``ADGroupService.get_user_direct_groups`` and
+``ADGroupService.resolve_primary_group`` happy and edge paths.
+"""
+
+import sys
+from pathlib import Path
+import unittest
+from unittest.mock import MagicMock
+
+SRC_ROOT = Path(__file__).resolve().parents[2]
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from python_apis.services.ad_group_service import ADGroupService
+from python_apis.models.ad_group import ADGroup
+from python_apis.models.ad_user import ADUser
+
+
+def _group_dict(dn: str, name: str = 'Team') -> dict:
+    """Build a minimal valid raw group record (passes ADGroupSchema)."""
+    return {
+        'distinguishedName': dn,
+        'name': name,
+        'instanceType': 4,
+        'sAMAccountType': 268435456,
+        'groupType': -2147483646,
+        'objectSid': 'S-1-5-21-1-2-3-1105',
+    }
+
+
+class TestMembershipAPIs(unittest.TestCase):
+    """Validate direct-group and primary-group resolution."""
+
+    def setUp(self):
+        self.mock_ad_connection = MagicMock()
+        self.mock_sql_connection = MagicMock()
+        self.service = ADGroupService(
+            ad_connection=self.mock_ad_connection,
+            sql_connection=self.mock_sql_connection,
+        )
+
+    # --- get_user_direct_groups -------------------------------------------
+
+    def test_direct_groups_happy_path_with_aduser(self):
+        self.mock_ad_connection.search.return_value = [
+            _group_dict('CN=Team A,DC=example,DC=com', 'Team A'),
+            _group_dict('CN=Team B,DC=example,DC=com', 'Team B'),
+        ]
+        user = ADUser(distinguishedName='CN=John,DC=example,DC=com')
+
+        groups = self.service.get_user_direct_groups(user)
+
+        self.assertEqual(len(groups), 2)
+        self.assertTrue(all(isinstance(g, ADGroup) for g in groups))
+        self.assertEqual({g.name for g in groups}, {'Team A', 'Team B'})
+        search_filter = self.mock_ad_connection.search.call_args[0][0]
+        self.assertEqual(
+            search_filter,
+            '(&(objectClass=group)(member=CN=John,DC=example,DC=com))',
+        )
+
+    def test_direct_groups_accepts_dn_string(self):
+        self.mock_ad_connection.search.return_value = [
+            _group_dict('CN=Team A,DC=example,DC=com', 'Team A'),
+        ]
+
+        groups = self.service.get_user_direct_groups('CN=Jane,DC=example,DC=com')
+
+        self.assertEqual(len(groups), 1)
+        search_filter = self.mock_ad_connection.search.call_args[0][0]
+        self.assertIn('(member=CN=Jane,DC=example,DC=com)', search_filter)
+
+    def test_direct_groups_empty_returns_empty_list(self):
+        self.mock_ad_connection.search.return_value = []
+
+        groups = self.service.get_user_direct_groups('CN=Nobody,DC=example,DC=com')
+
+        self.assertEqual(groups, [])
+
+    def test_direct_groups_escapes_filter_value(self):
+        self.mock_ad_connection.search.return_value = []
+
+        self.service.get_user_direct_groups('CN=a(b)*,DC=example,DC=com')
+
+        search_filter = self.mock_ad_connection.search.call_args[0][0]
+        # Special chars must be escaped to prevent LDAP filter injection.
+        self.assertIn(r'\28', search_filter)  # (
+        self.assertIn(r'\29', search_filter)  # )
+        self.assertIn(r'\2a', search_filter)  # *
+
+    def test_direct_groups_missing_dn_returns_empty_without_search(self):
+        user = ADUser(distinguishedName=None)
+
+        groups = self.service.get_user_direct_groups(user)
+
+        self.assertEqual(groups, [])
+        self.mock_ad_connection.search.assert_not_called()
+
+    # --- resolve_primary_group --------------------------------------------
+
+    def test_primary_group_happy_path_with_aduser(self):
+        self.mock_ad_connection.search.return_value = [
+            _group_dict('CN=Domain Users,DC=example,DC=com', 'Domain Users'),
+        ]
+        user = ADUser(
+            distinguishedName='CN=John,DC=example,DC=com',
+            primaryGroupID='513',
+        )
+
+        group = self.service.resolve_primary_group(user)
+
+        self.assertIsInstance(group, ADGroup)
+        self.assertEqual(group.name, 'Domain Users')
+        search_filter = self.mock_ad_connection.search.call_args[0][0]
+        self.assertEqual(
+            search_filter,
+            '(&(objectClass=group)(primaryGroupToken=513))',
+        )
+
+    def test_primary_group_accepts_rid_string(self):
+        self.mock_ad_connection.search.return_value = [
+            _group_dict('CN=Domain Users,DC=example,DC=com', 'Domain Users'),
+        ]
+
+        group = self.service.resolve_primary_group('513')
+
+        self.assertIsInstance(group, ADGroup)
+        search_filter = self.mock_ad_connection.search.call_args[0][0]
+        self.assertIn('(primaryGroupToken=513)', search_filter)
+
+    def test_primary_group_missing_id_returns_none_without_search(self):
+        user = ADUser(distinguishedName='CN=John,DC=example,DC=com', primaryGroupID=None)
+
+        group = self.service.resolve_primary_group(user)
+
+        self.assertIsNone(group)
+        self.mock_ad_connection.search.assert_not_called()
+
+    def test_primary_group_no_match_returns_none(self):
+        self.mock_ad_connection.search.return_value = []
+        user = ADUser(
+            distinguishedName='CN=John,DC=example,DC=com',
+            primaryGroupID='999',
+        )
+
+        group = self.service.resolve_primary_group(user)
+
+        self.assertIsNone(group)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

Adds two explicit, typed AD membership read APIs (issue #22) so callers can resolve a user's group memberships without hand-writing LDAP filters. Both live on `ADGroupService` (the group authority that already owns `ADGroup`/`ADGroupSchema`) and reuse the existing retry-capable `ADConnection.search` read path, so retry telemetry is captured automatically.

The change is **purely additive and backward-compatible** — no existing signatures or behavior change.

## Changes

- **`get_user_direct_groups(user: ADUser | str, compatibility_mode=None) -> list[ADGroup]`** ([ad_group_service.py](src/python_apis/services/ad_group_service.py)): returns the groups a user is a *direct* member of via `(&(objectClass=group)(member=<userDN>))`. Accepts an `ADUser` or DN string; returns `[]` for a falsy DN without an AD call.
- **`resolve_primary_group(user: ADUser | str, compatibility_mode=None) -> ADGroup | None`**: resolves the user's `primaryGroupID` against the group `primaryGroupToken` constructed attribute via `(&(objectClass=group)(primaryGroupToken=<id>))`. Returns `None` gracefully (no AD call) when the user has no `primaryGroupID`, and `None` on no match.
- **Shared helper `_groups_from_search(search_filter)`**: runs the search, annotates group-type name, validates via `ADGroupSchema`, and skips (logging) invalid records rather than dropping silently — mirroring `get_groups_from_ad`.
- **Security:** all user-supplied filter values are escaped with `ldap3.utils.conv.escape_filter_chars` to prevent LDAP filter injection.
- **Tests** ([test_membership_apis.py](src/tests/test_services/test_membership_apis.py)): 9 contract tests covering happy and edge paths.
- **CHANGELOG.md**: documented under Unreleased → Added.

## Testing

- `python -m unittest discover -s src/tests -p "test_*.py"` — 187 tests pass.
- `pylint src/python_apis/` — 10.00/10.
- Edge paths covered: empty membership → `[]`; missing DN → `[]` (no search); missing `primaryGroupID` → `None` (no search); no token match → `None`; `ADUser` vs DN/RID string input; LDAP filter-value escaping.

SemVer: **semver:minor** (additive, backward-compatible).

Closes #22