### PR TITLE
feat(#23): add transitive groups and paged group members APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   paging (`page_size`/`offset`) and an optional `max_members` cap; both accept an `ADUser`/`ADGroup`
   or distinguishedName string and escape LDAP filter values (additive, backward-compatible)
 - `ADMembersPage` typed paged response model (exported from `python_apis.models`) and
-  `ADConnection.get_ranged_attribute` for LDAP ranged multi-valued attribute retrieval
+  `ADConnection.get_ranged_attribute` for LDAP ranged multi-valued attribute retrieval, with an
+  optional `limit` to early-stop range reads (so `max_members` bounds LDAP traffic on large groups)
+  and resilience to empty ranged echoes returned alongside the real bounded range
 - Contract tests for transitive group resolution, paged group member retrieval, and ranged-attribute
   assembly
 - Canonical membership API usage example (`examples/membership_apis.py`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   distinguishedName string; both escape LDAP filter values and reuse the retry-capable read path
   (additive, backward-compatible)
 - Contract tests for the membership APIs covering happy and edge paths
+- Membership APIs v2 on `ADGroupService` (issue #23): `get_user_transitive_groups(user)` returning
+  every group a user belongs to including nested memberships (`list[ADGroup]`, sorted by
+  `distinguishedName` for determinism) via the AD matching rule `LDAP_MATCHING_RULE_IN_CHAIN`
+  (`member:1.2.840.113556.1.4.1941:=<userDN>`), and `get_group_members(group)` returning a paged
+  `ADMembersPage` (`members`, `total_count`, `page_info`, `truncated`) of member distinguishedNames
+  that scales to large groups via LDAP ranged retrieval (`member;range=lo-hi`) with client-side
+  paging (`page_size`/`offset`) and an optional `max_members` cap; both accept an `ADUser`/`ADGroup`
+  or distinguishedName string and escape LDAP filter values (additive, backward-compatible)
+- `ADMembersPage` typed paged response model (exported from `python_apis.models`) and
+  `ADConnection.get_ranged_attribute` for LDAP ranged multi-valued attribute retrieval
+- Contract tests for transitive group resolution, paged group member retrieval, and ranged-attribute
+  assembly
+- Canonical membership API usage example (`examples/membership_apis.py`)
 
 ### Fixed
 

--- a/examples/membership_apis.py
+++ b/examples/membership_apis.py
@@ -1,0 +1,79 @@
+"""Canonical usage examples for the AD membership APIs v2 (issue #23).
+
+Demonstrates the two read APIs added to ``ADGroupService``:
+
+* :meth:`ADGroupService.get_user_transitive_groups` - resolve every group a user
+  belongs to, including nested (indirect) memberships, deterministically.
+* :meth:`ADGroupService.get_group_members` - read a group's members at scale
+  using LDAP ranged retrieval, returning a paged ``ADMembersPage`` envelope with
+  ``total_count``, ``page_info`` and ``truncated``.
+
+These examples import only the public package surface. They assume the standard
+in-domain AD connection environment variables (``LDAP_SERVER_LIST``,
+``SEARCH_BASE``, and the AD DB settings) are configured; see the project README.
+Run with: ``python examples/membership_apis.py``.
+"""
+
+from python_apis.models import ADMembersPage
+from python_apis.services import ADGroupService
+
+
+def print_transitive_groups(service: ADGroupService, user_dn: str) -> None:
+    """Print all (direct and nested) groups the user belongs to."""
+
+    groups = service.get_user_transitive_groups(user_dn)
+    print(f"{user_dn} is a (transitive) member of {len(groups)} groups:")
+    for group in groups:
+        print(f"  - {group.distinguishedName}")
+
+
+def iterate_group_members(
+    service: ADGroupService,
+    group_dn: str,
+    page_size: int = 500,
+) -> list[str]:
+    """Page through every member of a group and return the collected DNs.
+
+    Iterates by following ``page_info['next_offset']`` until ``has_next_page``
+    is ``False``, which is the canonical paging loop for large groups.
+    """
+
+    all_members: list[str] = []
+    offset = 0
+    while True:
+        page: ADMembersPage = service.get_group_members(
+            group_dn,
+            page_size=page_size,
+            offset=offset,
+        )
+        all_members.extend(page.members)
+        print(
+            f"Fetched {len(page.members)} members "
+            f"(offset={page.page_info['offset']}, total={page.total_count})"
+        )
+        if not page.page_info["has_next_page"]:
+            break
+        offset = page.page_info["next_offset"]
+
+    return all_members
+
+
+def main() -> None:
+    """Run the membership API examples against the configured AD environment."""
+
+    service = ADGroupService()
+
+    # 1) Resolve a user's full (nested) group membership.
+    print_transitive_groups(service, "CN=John Doe,OU=Users,DC=example,DC=com")
+
+    # 2) Page through a (potentially very large) group's members.
+    members = iterate_group_members(
+        service,
+        "CN=All Staff,OU=Groups,DC=example,DC=com",
+        page_size=500,
+    )
+    print(f"Collected {len(members)} total members.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/python_apis/apis/ad_api.py
+++ b/src/python_apis/apis/ad_api.py
@@ -325,6 +325,12 @@ class ADConnection:
             if key != attribute and not key.startswith(f"{attribute};range="):
                 continue
             values = value if isinstance(value, list) else [value]
+            if not values:
+                # AD may echo the requested range back as an empty attribute
+                # (for example ``member;range=0-*``) alongside the real bounded
+                # range (``member;range=0-1499``). Skip empty echoes so the
+                # non-empty range drives assembly instead of stopping early.
+                continue
             if ";range=" not in key:
                 return values, None
             high = key.rsplit("-", 1)[-1]
@@ -334,7 +340,12 @@ class ADConnection:
         return [], None
 
     @_auto_reconnect("read")
-    def get_ranged_attribute(self, distinguished_name: str, attribute: str) -> list[str]:
+    def get_ranged_attribute(
+        self,
+        distinguished_name: str,
+        attribute: str,
+        limit: int | None = None,
+    ) -> list[str]:
         """Retrieve all values of a multi-valued attribute via LDAP ranged reads.
 
         Active Directory caps how many values of a multi-valued attribute (for
@@ -347,9 +358,15 @@ class ADConnection:
         Args:
             distinguished_name (str): DN of the object to read.
             attribute (str): The multi-valued attribute to assemble.
+            limit (int | None): Optional early-stop bound. When provided, range
+                reads stop as soon as at least ``limit`` values are collected and
+                the result is truncated to ``limit``; this avoids unbounded LDAP
+                traffic/memory for very large attributes when the caller only
+                needs a bounded number of values. ``None`` reads every range.
 
         Returns:
-            list[str]: All values of ``attribute`` across every range.
+            list[str]: Values of ``attribute`` in server order (at most ``limit``
+            when ``limit`` is set).
         """
 
         values: list[str] = []
@@ -367,6 +384,8 @@ class ADConnection:
             entry_attributes = self.connection.response[0].get("attributes", {}) or {}
             chunk, next_start = self._parse_ranged_attribute(entry_attributes, attribute)
             values.extend(chunk)
+            if limit is not None and len(values) >= limit:
+                return values[:limit]
             if next_start is None:
                 break
             start = next_start

--- a/src/python_apis/apis/ad_api.py
+++ b/src/python_apis/apis/ad_api.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from ldap3.utils.log import set_library_log_detail_level, BASIC
-from ldap3 import (ALL_ATTRIBUTES, MODIFY_ADD, MODIFY_DELETE,
+from ldap3 import (ALL_ATTRIBUTES, BASE, MODIFY_ADD, MODIFY_DELETE,
                    MODIFY_REPLACE, ROUND_ROBIN, SASL, SUBTREE, GSSAPI,
                    Connection, Server, ServerPool, Tls)
 from ldap3.core.exceptions import LDAPCommunicationError, LDAPSessionTerminatedByServerError
@@ -307,6 +307,70 @@ class ADConnection:
 
         search_result = self.search(search_filter, attributes)
         return search_result[0] if len(search_result) > 0 else collections.defaultdict(lambda: '')
+
+    @staticmethod
+    def _parse_ranged_attribute(
+        attributes: dict[str, Any], attribute: str
+    ) -> tuple[list[str], int | None]:
+        """Extract values and the next range start from a ranged search result.
+
+        Active Directory returns large multi-valued attributes under a ranged
+        key such as ``member;range=0-1499``. This inspects ``attributes`` for
+        either the plain ``attribute`` key (small object, whole value returned)
+        or its ranged variant and returns ``(values, next_start)`` where
+        ``next_start`` is ``None`` once the terminal range (``*``) is reached.
+        """
+
+        for key, value in attributes.items():
+            if key != attribute and not key.startswith(f"{attribute};range="):
+                continue
+            values = value if isinstance(value, list) else [value]
+            if ";range=" not in key:
+                return values, None
+            high = key.rsplit("-", 1)[-1]
+            if high == "*":
+                return values, None
+            return values, int(high) + 1
+        return [], None
+
+    @_auto_reconnect("read")
+    def get_ranged_attribute(self, distinguished_name: str, attribute: str) -> list[str]:
+        """Retrieve all values of a multi-valued attribute via LDAP ranged reads.
+
+        Active Directory caps how many values of a multi-valued attribute (for
+        example ``member`` on a large group) it returns at once and exposes the
+        remainder through the ``attribute;range=lo-hi`` mechanism. This walks
+        every range (base-scoped reads of ``distinguished_name``) until the
+        server returns the terminal range and returns the assembled values in
+        server order. Returns ``[]`` when the object or attribute is absent.
+
+        Args:
+            distinguished_name (str): DN of the object to read.
+            attribute (str): The multi-valued attribute to assemble.
+
+        Returns:
+            list[str]: All values of ``attribute`` across every range.
+        """
+
+        values: list[str] = []
+        start = 0
+        while True:
+            ranged_key = f"{attribute};range={start}-*"
+            found = self.connection.search(
+                search_base=distinguished_name,
+                search_filter="(objectClass=*)",
+                search_scope=BASE,
+                attributes=[ranged_key],
+            )
+            if not found or not self.connection.response:
+                break
+            entry_attributes = self.connection.response[0].get("attributes", {}) or {}
+            chunk, next_start = self._parse_ranged_attribute(entry_attributes, attribute)
+            values.extend(chunk)
+            if next_start is None:
+                break
+            start = next_start
+        return values
 
     @_auto_reconnect("write")
     def modify(self, distinguished_name: str, changes: list[tuple[str, str]]) -> dict[str, Any]:

--- a/src/python_apis/models/__init__.py
+++ b/src/python_apis/models/__init__.py
@@ -13,6 +13,7 @@ from python_apis.models.ad_responses import (
     ADOperationEnvelope,
     ADEntry,
     ADSearchResponse,
+    ADMembersPage,
 )
 
 from python_apis.models.sap_employee import Employee
@@ -29,6 +30,7 @@ __all__ = [
     "ADOperationEnvelope",
     "ADEntry",
     "ADSearchResponse",
+    "ADMembersPage",
 
     "Employee",
 

--- a/src/python_apis/models/ad_responses.py
+++ b/src/python_apis/models/ad_responses.py
@@ -307,6 +307,28 @@ class ADSearchResponse(BaseModel, Sequence):
         return cls(entries=[ADEntry.from_legacy(payload) for payload in payloads])
 
 
+class ADMembersPage(BaseModel):
+    """Typed, paginated view of an AD group's members.
+
+    Returned by ``ADGroupService.get_group_members`` to expose a single page of
+    member distinguished names together with paging metadata. The model is the
+    response surface for both AD mechanisms used to read large groups: server
+    paged search and LDAP ranged attribute retrieval (``member;range=lo-hi``).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    members: list[str] = Field(default_factory=list)
+    total_count: int = 0
+    truncated: bool = False
+    page_info: dict[str, Any] = Field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain, JSON-serializable ``dict`` of this page."""
+
+        return self.model_dump()
+
+
 __all__: list[str] = [
     # pylint: disable=duplicate-code
     "ADResponse",
@@ -314,4 +336,5 @@ __all__: list[str] = [
     "ADOperationEnvelope",
     "ADEntry",
     "ADSearchResponse",
+    "ADMembersPage",
 ]

--- a/src/python_apis/services/ad_group_service.py
+++ b/src/python_apis/services/ad_group_service.py
@@ -21,6 +21,10 @@ from python_apis.services.compatibility_mode import (
     resolve_service_compatibility_mode,
 )
 
+# AD matching rule OID for transitive (nested) membership evaluation.
+# Filtering ``member`` with this rule walks the full membership chain.
+LDAP_MATCHING_RULE_IN_CHAIN = "1.2.840.113556.1.4.1941"
+
 class ADGroupService:
     """Service class for interacting with Active Directory groups.
 
@@ -304,6 +308,47 @@ class ADGroupService:
         search_filter = f"(&(objectClass=group)(objectSid={escaped_sid}))"
         groups = self._groups_from_search(search_filter)
         return groups[0] if groups else None
+
+    def get_user_transitive_groups(
+        self,
+        user: ADUser | str,
+        compatibility_mode: str | None = None,
+    ) -> list[ADGroup]:
+        """Return all groups a user belongs to, including nested memberships.
+
+        Unlike :meth:`get_user_direct_groups` (direct memberships only), this
+        resolves the full membership chain using the AD matching rule
+        ``LDAP_MATCHING_RULE_IN_CHAIN`` (OID ``1.2.840.113556.1.4.1941``):
+        ``(member:1.2.840.113556.1.4.1941:=<userDN>)``. Results are sorted by
+        ``distinguishedName`` so repeated calls are deterministic. Note that a
+        user's *primary* group is not part of the ``member`` chain; use
+        :meth:`resolve_primary_group` for that.
+
+        Args:
+            user (ADUser | str): The user, or the user's distinguishedName.
+            compatibility_mode (str | None): Optional per-call compatibility mode
+                override (accepted for API symmetry; reads return typed models).
+
+        Returns:
+            list[ADGroup]: All (direct and nested) group memberships, ordered by
+            ``distinguishedName`` (empty list if none).
+        """
+
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
+        self.logger.debug(
+            "Using AD compatibility mode '%s' for get_user_transitive_groups", effective_mode
+        )
+
+        user_dn = user.distinguishedName if isinstance(user, ADUser) else user
+        if not user_dn:
+            return []
+
+        escaped_dn = escape_filter_chars(str(user_dn))
+        search_filter = (
+            f"(&(objectClass=group)(member:{LDAP_MATCHING_RULE_IN_CHAIN}:={escaped_dn}))"
+        )
+        groups = self._groups_from_search(search_filter)
+        return sorted(groups, key=lambda group: group.distinguishedName or "")
 
     def modify_group(
         self,

--- a/src/python_apis/services/ad_group_service.py
+++ b/src/python_apis/services/ad_group_service.py
@@ -14,7 +14,7 @@ from pydantic import ValidationError
 
 from dev_tools import timing_decorator
 from python_apis.apis import ADConnection, SQLConnection
-from python_apis.models import ADGroup, ADUser, base
+from python_apis.models import ADGroup, ADMembersPage, ADUser, base
 from python_apis.schemas import ADGroupSchema
 from python_apis.services.compatibility_mode import (
     finalize_ad_write_response,
@@ -349,6 +349,74 @@ class ADGroupService:
         )
         groups = self._groups_from_search(search_filter)
         return sorted(groups, key=lambda group: group.distinguishedName or "")
+
+    def get_group_members(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        group: ADGroup | str,
+        page_size: int = 500,
+        offset: int = 0,
+        max_members: int | None = None,
+        compatibility_mode: str | None = None,
+    ) -> ADMembersPage:
+        """Return a page of a group's member distinguished names at scale.
+
+        Reads the group's ``member`` attribute using LDAP ranged retrieval
+        (:meth:`ADConnection.get_ranged_attribute`), so it works for large
+        groups whose membership AD only returns in ``member;range=lo-hi`` chunks.
+        The assembled member DNs are then paged client-side and returned in an
+        :class:`ADMembersPage` envelope exposing ``total_count``, ``page_info``
+        and ``truncated``.
+
+        ``total_count`` is the number of members available for paging in this
+        response. When ``max_members`` is set and the group has more members,
+        the working set is capped to ``max_members`` and ``truncated`` is
+        ``True`` to signal that members beyond the cap were omitted.
+
+        Args:
+            group (ADGroup | str): The group, or the group's distinguishedName.
+            page_size (int): Maximum members per page. ``0`` or negative returns
+                all members (from ``offset``) in a single page.
+            offset (int): Zero-based index of the first member to return.
+            max_members (int | None): Optional hard cap on the total members
+                considered; protects against unbounded reads of very large
+                groups. ``None`` means no cap.
+            compatibility_mode (str | None): Optional per-call compatibility mode
+                override (accepted for API symmetry; reads return typed models).
+
+        Returns:
+            ADMembersPage: The requested page of member DNs plus paging metadata.
+        """
+
+        effective_mode = self._resolve_effective_mode(compatibility_mode)
+        self.logger.debug(
+            "Using AD compatibility mode '%s' for get_group_members", effective_mode
+        )
+
+        group_dn = group.distinguishedName if isinstance(group, ADGroup) else group
+        if not group_dn:
+            return ADMembersPage()
+
+        members = self.ad_connection.get_ranged_attribute(str(group_dn), "member")
+
+        truncated = max_members is not None and 0 <= max_members < len(members)
+        if truncated:
+            members = members[:max_members]
+
+        total_count = len(members)
+        start = min(max(offset, 0), total_count)
+        end = min(start + page_size, total_count) if page_size and page_size > 0 else total_count
+
+        return ADMembersPage(
+            members=members[start:end],
+            total_count=total_count,
+            truncated=truncated,
+            page_info={
+                "page_size": page_size,
+                "offset": start,
+                "next_offset": end if end < total_count else None,
+                "has_next_page": end < total_count,
+            },
+        )
 
     def modify_group(
         self,

--- a/src/python_apis/services/ad_group_service.py
+++ b/src/python_apis/services/ad_group_service.py
@@ -370,7 +370,10 @@ class ADGroupService:
         ``total_count`` is the number of members available for paging in this
         response. When ``max_members`` is set and the group has more members,
         the working set is capped to ``max_members`` and ``truncated`` is
-        ``True`` to signal that members beyond the cap were omitted.
+        ``True`` to signal that members beyond the cap were omitted. The cap is
+        pushed into the ranged read (:meth:`ADConnection.get_ranged_attribute`),
+        so an oversized group stops fetching ranges shortly after the cap is
+        reached rather than materializing the entire membership.
 
         Args:
             group (ADGroup | str): The group, or the group's distinguishedName.
@@ -394,9 +397,14 @@ class ADGroupService:
 
         group_dn = group.distinguishedName if isinstance(group, ADGroup) else group
         if not group_dn:
-            return ADMembersPage()
+            return ADMembersPage(page_info=self._members_page_info(page_size, 0, 0))
 
-        members = self.ad_connection.get_ranged_attribute(str(group_dn), "member")
+        # Read one past the cap so truncation can be detected while still
+        # bounding the ranged read for very large groups.
+        fetch_limit = max_members + 1 if max_members is not None and max_members >= 0 else None
+        members = self.ad_connection.get_ranged_attribute(
+            str(group_dn), "member", limit=fetch_limit
+        )
 
         truncated = max_members is not None and 0 <= max_members < len(members)
         if truncated:
@@ -410,13 +418,31 @@ class ADGroupService:
             members=members[start:end],
             total_count=total_count,
             truncated=truncated,
-            page_info={
-                "page_size": page_size,
-                "offset": start,
-                "next_offset": end if end < total_count else None,
-                "has_next_page": end < total_count,
-            },
+            page_info=self._members_page_info(page_size, start, end, total_count),
         )
+
+    @staticmethod
+    def _members_page_info(
+        page_size: int,
+        offset: int,
+        end: int,
+        total_count: int = 0,
+    ) -> dict[str, Any]:
+        """Build a consistently-shaped ``page_info`` mapping for member pages.
+
+        Always returns the same key surface (``page_size``, ``offset``,
+        ``next_offset``, ``has_next_page``) so callers following the paging
+        contract never hit a ``KeyError`` -- including the empty/missing-group
+        early-return path.
+        """
+
+        has_next_page = end < total_count
+        return {
+            "page_size": page_size,
+            "offset": offset,
+            "next_offset": end if has_next_page else None,
+            "has_next_page": has_next_page,
+        }
 
     def modify_group(
         self,

--- a/src/tests/test_services/test_membership_apis_v2.py
+++ b/src/tests/test_services/test_membership_apis_v2.py
@@ -1,0 +1,304 @@
+"""Contract tests for AD membership APIs v2 (issue #23).
+
+Covers ``ADGroupService.get_user_transitive_groups`` and
+``ADGroupService.get_group_members`` (paging + ranged retrieval), plus the
+``ADConnection`` ranged-attribute retrieval that backs group member reads.
+"""
+
+import sys
+from pathlib import Path
+import unittest
+from unittest.mock import MagicMock
+
+SRC_ROOT = Path(__file__).resolve().parents[2]
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from python_apis.apis.ad_api import ADConnection
+from python_apis.services.ad_group_service import (
+    ADGroupService,
+    LDAP_MATCHING_RULE_IN_CHAIN,
+)
+from python_apis.models.ad_group import ADGroup
+from python_apis.models.ad_user import ADUser
+
+
+def _group_dict(dn: str, name: str = 'Team') -> dict:
+    """Build a minimal valid raw group record (passes ADGroupSchema)."""
+    return {
+        'distinguishedName': dn,
+        'name': name,
+        'instanceType': 4,
+        'sAMAccountType': 268435456,
+        'groupType': -2147483646,
+        'objectSid': 'S-1-5-21-1-2-3-1105',
+    }
+
+
+class TestTransitiveGroups(unittest.TestCase):
+    """Validate nested (transitive) group resolution."""
+
+    def setUp(self):
+        self.mock_ad_connection = MagicMock()
+        self.service = ADGroupService(
+            ad_connection=self.mock_ad_connection,
+            sql_connection=MagicMock(),
+        )
+
+    def test_transitive_groups_happy_path_uses_in_chain_rule(self):
+        self.mock_ad_connection.search.return_value = [
+            _group_dict('CN=Team A,DC=example,DC=com', 'Team A'),
+        ]
+        user = ADUser(distinguishedName='CN=John,DC=example,DC=com')
+
+        groups = self.service.get_user_transitive_groups(user)
+
+        self.assertEqual(len(groups), 1)
+        self.assertTrue(all(isinstance(g, ADGroup) for g in groups))
+        search_filter = self.mock_ad_connection.search.call_args[0][0]
+        self.assertEqual(
+            search_filter,
+            f"(&(objectClass=group)(member:{LDAP_MATCHING_RULE_IN_CHAIN}:="
+            "CN=John,DC=example,DC=com))",
+        )
+
+    def test_transitive_groups_accepts_dn_string(self):
+        self.mock_ad_connection.search.return_value = [
+            _group_dict('CN=Team A,DC=example,DC=com', 'Team A'),
+        ]
+
+        groups = self.service.get_user_transitive_groups('CN=Jane,DC=example,DC=com')
+
+        self.assertEqual(len(groups), 1)
+        search_filter = self.mock_ad_connection.search.call_args[0][0]
+        self.assertIn(f"(member:{LDAP_MATCHING_RULE_IN_CHAIN}:=CN=Jane,DC=example,DC=com)",
+                      search_filter)
+
+    def test_transitive_groups_results_sorted_by_dn(self):
+        self.mock_ad_connection.search.return_value = [
+            _group_dict('CN=Zeta,DC=example,DC=com', 'Zeta'),
+            _group_dict('CN=Alpha,DC=example,DC=com', 'Alpha'),
+            _group_dict('CN=Mu,DC=example,DC=com', 'Mu'),
+        ]
+        user = ADUser(distinguishedName='CN=John,DC=example,DC=com')
+
+        groups = self.service.get_user_transitive_groups(user)
+
+        self.assertEqual(
+            [g.distinguishedName for g in groups],
+            [
+                'CN=Alpha,DC=example,DC=com',
+                'CN=Mu,DC=example,DC=com',
+                'CN=Zeta,DC=example,DC=com',
+            ],
+        )
+
+    def test_transitive_groups_escapes_filter_value(self):
+        self.mock_ad_connection.search.return_value = []
+
+        self.service.get_user_transitive_groups('CN=a(b)*,DC=example,DC=com')
+
+        search_filter = self.mock_ad_connection.search.call_args[0][0]
+        self.assertIn(r'\28', search_filter)  # (
+        self.assertIn(r'\29', search_filter)  # )
+        self.assertIn(r'\2a', search_filter)  # *
+
+    def test_transitive_groups_missing_dn_returns_empty_without_search(self):
+        groups = self.service.get_user_transitive_groups(ADUser(distinguishedName=None))
+
+        self.assertEqual(groups, [])
+        self.mock_ad_connection.search.assert_not_called()
+
+
+class TestGroupMembers(unittest.TestCase):
+    """Validate paged group member retrieval."""
+
+    def setUp(self):
+        self.mock_ad_connection = MagicMock()
+        self.service = ADGroupService(
+            ad_connection=self.mock_ad_connection,
+            sql_connection=MagicMock(),
+        )
+
+    def _set_members(self, count: int):
+        members = [f'CN=User{i:04d},DC=example,DC=com' for i in range(count)]
+        self.mock_ad_connection.get_ranged_attribute.return_value = members
+        return members
+
+    def test_members_happy_path_single_page(self):
+        members = self._set_members(3)
+
+        page = self.service.get_group_members('CN=Team,DC=example,DC=com')
+
+        self.assertEqual(page.members, members)
+        self.assertEqual(page.total_count, 3)
+        self.assertFalse(page.truncated)
+        self.assertFalse(page.page_info['has_next_page'])
+        self.assertIsNone(page.page_info['next_offset'])
+        # Reads the group's member attribute via ranged retrieval.
+        self.mock_ad_connection.get_ranged_attribute.assert_called_once_with(
+            'CN=Team,DC=example,DC=com', 'member'
+        )
+
+    def test_members_accepts_adgroup_instance(self):
+        self._set_members(2)
+        group = ADGroup(distinguishedName='CN=Team,DC=example,DC=com', name='Team')
+
+        page = self.service.get_group_members(group)
+
+        self.assertEqual(page.total_count, 2)
+        self.mock_ad_connection.get_ranged_attribute.assert_called_once_with(
+            'CN=Team,DC=example,DC=com', 'member'
+        )
+
+    def test_members_paging_returns_requested_slice(self):
+        members = self._set_members(10)
+
+        page = self.service.get_group_members(
+            'CN=Team,DC=example,DC=com', page_size=4, offset=4
+        )
+
+        self.assertEqual(page.members, members[4:8])
+        self.assertEqual(page.total_count, 10)
+        self.assertEqual(page.page_info['offset'], 4)
+        self.assertEqual(page.page_info['page_size'], 4)
+        self.assertEqual(page.page_info['next_offset'], 8)
+        self.assertTrue(page.page_info['has_next_page'])
+
+    def test_members_last_page_has_no_next(self):
+        members = self._set_members(10)
+
+        page = self.service.get_group_members(
+            'CN=Team,DC=example,DC=com', page_size=4, offset=8
+        )
+
+        self.assertEqual(page.members, members[8:10])
+        self.assertFalse(page.page_info['has_next_page'])
+        self.assertIsNone(page.page_info['next_offset'])
+
+    def test_members_non_positive_page_size_returns_all_from_offset(self):
+        members = self._set_members(5)
+
+        page = self.service.get_group_members(
+            'CN=Team,DC=example,DC=com', page_size=0, offset=2
+        )
+
+        self.assertEqual(page.members, members[2:])
+        self.assertFalse(page.page_info['has_next_page'])
+
+    def test_members_truncated_when_max_members_exceeded(self):
+        self._set_members(10)
+
+        page = self.service.get_group_members(
+            'CN=Team,DC=example,DC=com', page_size=50, max_members=3
+        )
+
+        self.assertTrue(page.truncated)
+        self.assertEqual(page.total_count, 3)
+        self.assertEqual(len(page.members), 3)
+
+    def test_members_offset_beyond_total_returns_empty_page(self):
+        self._set_members(3)
+
+        page = self.service.get_group_members(
+            'CN=Team,DC=example,DC=com', page_size=5, offset=99
+        )
+
+        self.assertEqual(page.members, [])
+        self.assertEqual(page.total_count, 3)
+        self.assertFalse(page.page_info['has_next_page'])
+
+    def test_members_missing_dn_returns_empty_page_without_read(self):
+        page = self.service.get_group_members(ADGroup(distinguishedName=None, name='X'))
+
+        self.assertEqual(page.members, [])
+        self.assertEqual(page.total_count, 0)
+        self.assertFalse(page.truncated)
+        self.mock_ad_connection.get_ranged_attribute.assert_not_called()
+
+
+class TestRangedAttributeRetrieval(unittest.TestCase):
+    """Validate ADConnection LDAP ranged attribute assembly."""
+
+    def setUp(self):
+        # Build an ADConnection without establishing a real LDAP session.
+        self.connection = ADConnection.__new__(ADConnection)
+        self.connection.connection = MagicMock()
+        self.connection._last_retry_telemetry = None  # pylint: disable=protected-access
+
+    def _stub_ranges(self, range_responses):
+        """Make connection.search yield the given range responses in order."""
+        state = {'index': 0}
+
+        def search_side_effect(**_kwargs):
+            attributes = range_responses[state['index']]
+            self.connection.connection.response = [{'attributes': attributes}]
+            state['index'] += 1
+            return True
+
+        self.connection.connection.search.side_effect = search_side_effect
+
+    def test_parse_ranged_attribute_plain_key_is_terminal(self):
+        values, nxt = ADConnection._parse_ranged_attribute(  # pylint: disable=protected-access
+            {'member': ['CN=a', 'CN=b']}, 'member'
+        )
+        self.assertEqual(values, ['CN=a', 'CN=b'])
+        self.assertIsNone(nxt)
+
+    def test_parse_ranged_attribute_non_terminal_returns_next_start(self):
+        values, nxt = ADConnection._parse_ranged_attribute(  # pylint: disable=protected-access
+            {'member;range=0-1': ['CN=a', 'CN=b']}, 'member'
+        )
+        self.assertEqual(values, ['CN=a', 'CN=b'])
+        self.assertEqual(nxt, 2)
+
+    def test_parse_ranged_attribute_terminal_star(self):
+        values, nxt = ADConnection._parse_ranged_attribute(  # pylint: disable=protected-access
+            {'member;range=2-*': ['CN=c']}, 'member'
+        )
+        self.assertEqual(values, ['CN=c'])
+        self.assertIsNone(nxt)
+
+    def test_parse_ranged_attribute_missing_attribute(self):
+        values, nxt = ADConnection._parse_ranged_attribute(  # pylint: disable=protected-access
+            {'cn': ['Team']}, 'member'
+        )
+        self.assertEqual(values, [])
+        self.assertIsNone(nxt)
+
+    def test_get_ranged_attribute_assembles_multiple_ranges(self):
+        self._stub_ranges([
+            {'member;range=0-1': ['CN=a', 'CN=b']},
+            {'member;range=2-3': ['CN=c', 'CN=d']},
+            {'member;range=4-*': ['CN=e']},
+        ])
+
+        values = self.connection.get_ranged_attribute('CN=Team,DC=example,DC=com', 'member')
+
+        self.assertEqual(values, ['CN=a', 'CN=b', 'CN=c', 'CN=d', 'CN=e'])
+        self.assertEqual(self.connection.connection.search.call_count, 3)
+
+    def test_get_ranged_attribute_single_range(self):
+        self._stub_ranges([
+            {'member;range=0-*': ['CN=a', 'CN=b']},
+        ])
+
+        values = self.connection.get_ranged_attribute('CN=Team,DC=example,DC=com', 'member')
+
+        self.assertEqual(values, ['CN=a', 'CN=b'])
+        self.assertEqual(self.connection.connection.search.call_count, 1)
+
+    def test_get_ranged_attribute_absent_object_returns_empty(self):
+        def search_side_effect(**_kwargs):
+            self.connection.connection.response = []
+            return False
+
+        self.connection.connection.search.side_effect = search_side_effect
+
+        values = self.connection.get_ranged_attribute('CN=Missing,DC=example,DC=com', 'member')
+
+        self.assertEqual(values, [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/test_services/test_membership_apis_v2.py
+++ b/src/tests/test_services/test_membership_apis_v2.py
@@ -137,7 +137,7 @@ class TestGroupMembers(unittest.TestCase):
         self.assertIsNone(page.page_info['next_offset'])
         # Reads the group's member attribute via ranged retrieval.
         self.mock_ad_connection.get_ranged_attribute.assert_called_once_with(
-            'CN=Team,DC=example,DC=com', 'member'
+            'CN=Team,DC=example,DC=com', 'member', limit=None
         )
 
     def test_members_accepts_adgroup_instance(self):
@@ -148,7 +148,7 @@ class TestGroupMembers(unittest.TestCase):
 
         self.assertEqual(page.total_count, 2)
         self.mock_ad_connection.get_ranged_attribute.assert_called_once_with(
-            'CN=Team,DC=example,DC=com', 'member'
+            'CN=Team,DC=example,DC=com', 'member', limit=None
         )
 
     def test_members_paging_returns_requested_slice(self):
@@ -197,6 +197,28 @@ class TestGroupMembers(unittest.TestCase):
         self.assertEqual(page.total_count, 3)
         self.assertEqual(len(page.members), 3)
 
+    def test_members_max_members_bounds_the_ranged_read(self):
+        self._set_members(10)
+
+        self.service.get_group_members(
+            'CN=Team,DC=example,DC=com', page_size=50, max_members=3
+        )
+
+        # The cap is pushed into the ranged read (one past the cap so truncation
+        # can still be detected) rather than fetching the whole membership.
+        self.mock_ad_connection.get_ranged_attribute.assert_called_once_with(
+            'CN=Team,DC=example,DC=com', 'member', limit=4
+        )
+
+    def test_members_no_cap_reads_every_range(self):
+        self._set_members(5)
+
+        self.service.get_group_members('CN=Team,DC=example,DC=com')
+
+        self.mock_ad_connection.get_ranged_attribute.assert_called_once_with(
+            'CN=Team,DC=example,DC=com', 'member', limit=None
+        )
+
     def test_members_offset_beyond_total_returns_empty_page(self):
         self._set_members(3)
 
@@ -215,6 +237,21 @@ class TestGroupMembers(unittest.TestCase):
         self.assertEqual(page.total_count, 0)
         self.assertFalse(page.truncated)
         self.mock_ad_connection.get_ranged_attribute.assert_not_called()
+
+    def test_members_missing_dn_page_info_is_consistently_shaped(self):
+        page = self.service.get_group_members(
+            ADGroup(distinguishedName=None, name='X'), page_size=25
+        )
+
+        # Paging callers must find the same keys here as on populated pages.
+        self.assertEqual(
+            set(page.page_info),
+            {'page_size', 'offset', 'next_offset', 'has_next_page'},
+        )
+        self.assertEqual(page.page_info['page_size'], 25)
+        self.assertEqual(page.page_info['offset'], 0)
+        self.assertIsNone(page.page_info['next_offset'])
+        self.assertFalse(page.page_info['has_next_page'])
 
 
 class TestRangedAttributeRetrieval(unittest.TestCase):
@@ -266,6 +303,14 @@ class TestRangedAttributeRetrieval(unittest.TestCase):
         self.assertEqual(values, [])
         self.assertIsNone(nxt)
 
+    def test_parse_ranged_attribute_skips_empty_echo(self):
+        # AD can echo the requested range back empty alongside the real range.
+        values, nxt = ADConnection._parse_ranged_attribute(  # pylint: disable=protected-access
+            {'member;range=0-*': [], 'member;range=0-1': ['CN=a', 'CN=b']}, 'member'
+        )
+        self.assertEqual(values, ['CN=a', 'CN=b'])
+        self.assertEqual(nxt, 2)
+
     def test_get_ranged_attribute_assembles_multiple_ranges(self):
         self._stub_ranges([
             {'member;range=0-1': ['CN=a', 'CN=b']},
@@ -287,6 +332,31 @@ class TestRangedAttributeRetrieval(unittest.TestCase):
 
         self.assertEqual(values, ['CN=a', 'CN=b'])
         self.assertEqual(self.connection.connection.search.call_count, 1)
+
+    def test_get_ranged_attribute_handles_empty_echo(self):
+        self._stub_ranges([
+            {'member;range=0-*': [], 'member;range=0-1': ['CN=a', 'CN=b']},
+            {'member;range=2-*': ['CN=c']},
+        ])
+
+        values = self.connection.get_ranged_attribute('CN=Team,DC=example,DC=com', 'member')
+
+        self.assertEqual(values, ['CN=a', 'CN=b', 'CN=c'])
+
+    def test_get_ranged_attribute_limit_stops_early(self):
+        self._stub_ranges([
+            {'member;range=0-1': ['CN=a', 'CN=b']},
+            {'member;range=2-3': ['CN=c', 'CN=d']},
+            {'member;range=4-*': ['CN=e']},
+        ])
+
+        values = self.connection.get_ranged_attribute(
+            'CN=Team,DC=example,DC=com', 'member', limit=3
+        )
+
+        # Stops after the cap is reached and trims to exactly ``limit``.
+        self.assertEqual(values, ['CN=a', 'CN=b', 'CN=c'])
+        self.assertEqual(self.connection.connection.search.call_count, 2)
 
     def test_get_ranged_attribute_absent_object_returns_empty(self):
         def search_side_effect(**_kwargs):


### PR DESCRIPTION
## Description

Adds membership APIs v2 to `ADGroupService` for nested group traversal and scalable group member retrieval, completing issue #23. Both APIs are additive and backward-compatible.

- `get_user_transitive_groups(user)` resolves **all** groups a user belongs to, including nested/indirect memberships, deterministically.
- `get_group_members(group)` returns a group's members **at scale**, using AD's LDAP ranged attribute retrieval plus client-side paging, in a typed envelope exposing `total_count`, `page_info`, and `truncated` (per the issue's response requirements).

## Changes

- **`ADMembersPage` response model** (`src/python_apis/models/ad_responses.py`): typed paged envelope with `members`, `total_count`, `page_info`, `truncated`; exported from `python_apis.models`.
- **Ranged retrieval** (`src/python_apis/apis/ad_api.py`): new `ADConnection.get_ranged_attribute(dn, attribute)` (`@_auto_reconnect("read")`) plus `_parse_ranged_attribute` helper that walks `attribute;range=lo-hi` chunks until the terminal `*` range and assembles all values in server order.
- **`get_user_transitive_groups`** (`src/python_apis/services/ad_group_service.py`): uses the AD matching rule `LDAP_MATCHING_RULE_IN_CHAIN` (`1.2.840.113556.1.4.1941`) — `(&(objectClass=group)(member:1.2.840.113556.1.4.1941:=<userDN>))` — reuses `_groups_from_search`, escapes the filter value, and sorts results by `distinguishedName` for determinism.
- **`get_group_members`** (`src/python_apis/services/ad_group_service.py`): reads `member` via ranged retrieval, applies an optional `max_members` cap (sets `truncated`), then slices `[offset:offset+page_size]` (`page_size<=0` returns all from offset) and returns an `ADMembersPage` with `page_size`/`offset`/`next_offset`/`has_next_page` page info.
- **Tests** (`src/tests/test_services/test_membership_apis_v2.py`): 20 new contract tests covering the IN_CHAIN filter + escaping + deterministic ordering, paging math, truncation, empty/missing inputs, and multi-range/single-range/absent ranged-attribute assembly.
- **Example** (`examples/membership_apis.py`): canonical usage of both APIs, including a paging loop that follows `page_info['next_offset']` until `has_next_page` is false.
- **CHANGELOG.md**: Unreleased → Added entry for issue #23.

## Testing

- `python -m unittest discover -s src/tests -p "test_*.py"` — 208 tests pass (+20).
- `pylint src/python_apis/` — 10.00/10.

---

**SemVer:** `semver:minor` (additive, backward-compatible). Please ensure exactly one SemVer label is set.

Closes #23