### PR TITLE
feat(#25): add multivalue dual-form support (raw + normalized + metadata)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Contract tests for the batch read v2 APIs (all-success/all-failure/mixed/empty and unchanged
   list-method signatures) and a canonical usage example (`examples/batch_read_v2.py`) plus migration
   guide (`docs/migration/ad-batch-read-v2.md`)
+- Multivalue dual-form support for AD attributes (issue #25): `ADMultiValue` exposes the `raw` source
+  value (preserved verbatim), a deterministically `normalized` `list[str]` (`values`), and
+  `metadata` (`ADMultiValueMetadata` with `source`/`normalized`/`count`/`delimiter`), plus an
+  `as_legacy_string()` accessor that reproduces the historic comma-joined string during the
+  transition. A pure `normalize_multivalue(raw, *, delimiter=",")` helper implements the documented
+  deterministic normalization rules. Existing schema field types and their comma-joining behavior are
+  unchanged (additive, backward-compatible; exported from `python_apis.models`)
+- Contract tests for the multivalue dual-form (normalization rules, determinism, legacy-accessor
+  parity, shape invariants), a migration guide documenting the normalization rules
+  (`docs/migration/ad-multivalue-dual-form.md`), and a usage example
+  (`examples/multivalue_dual_form.py`)
 
 ### Fixed
 

--- a/docs/migration/ad-multivalue-dual-form.md
+++ b/docs/migration/ad-multivalue-dual-form.md
@@ -33,9 +33,15 @@ behavior are **unchanged**; the dual-form is opt-in.
 | `count` | `int` | `len(values)`. |
 | `delimiter` | `str` | Delimiter used for splitting and the legacy accessor (default `","`). |
 
-`ADMultiValue.as_legacy_string(delimiter=None)` reproduces the historic
-delimiter-joined string so existing comma-joined consumers keep working during
-the transition. `ADMultiValue.to_dict()` returns a JSON-serializable payload.
+`ADMultiValue.as_legacy_string(delimiter=None)` reproduces the historic schema
+representation derived from `raw` **verbatim** (`','.join(map(str, value))` for
+list sources, the unchanged string for scalar sources, and `''` when absent), so
+existing comma-joined consumers keep working during the transition without the
+stripping/dropping that normalization applies. Passing an explicit `delimiter`
+instead joins the normalized `values` with that separator.
+`ADMultiValue.to_dict()` returns a JSON-serializable payload; non-JSON-native
+`raw` values (for example binary attributes or datetimes) are coerced to a safe
+form (`bytes` → hex, `datetime`/`date` → ISO-8601).
 
 ## Deterministic normalization rules
 

--- a/docs/migration/ad-multivalue-dual-form.md
+++ b/docs/migration/ad-multivalue-dual-form.md
@@ -1,0 +1,92 @@
+# Migration Guide: AD Multivalue Dual-Form (Issue #25)
+
+> Status: Additive, non-breaking (SemVer **minor**)
+> Related: [ADR 0001](../adr/0001-ad-response-modernization.md), issue #25
+
+Active Directory multivalue attributes (for example `proxyAddresses`, `memberOf`,
+`objectClass`) are returned by ldap3 as Python lists. The legacy schema path
+(`ADUserSchema`/`ADGroupSchema`/`ADOrganizationalUnitSchema`) flattens every list
+into a single comma-joined string, which **loses the raw source value, element
+boundaries, and ordering metadata**.
+
+Issue #25 adds an **additive** dual-form representation, `ADMultiValue`, that
+preserves the raw value, exposes a deterministically normalized `list[str]`, and
+carries metadata. The existing schema field types and their comma-joining
+behavior are **unchanged**; the dual-form is opt-in.
+
+## The dual-form contract
+
+`ADMultiValue` exposes:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `raw` | `Any` | Original AD source value, preserved verbatim (list/str/int/None). |
+| `values` | `list[str]` | Deterministically normalized list form. |
+| `metadata` | `ADMultiValueMetadata` | Source kind and normalization status. |
+
+`ADMultiValueMetadata` carries:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `source` | `"absent" \| "list" \| "scalar" \| "delimited_string"` | Kind of the raw value. |
+| `normalized` | `bool` | True when `values` was derived/transformed from `raw`. |
+| `count` | `int` | `len(values)`. |
+| `delimiter` | `str` | Delimiter used for splitting and the legacy accessor (default `","`). |
+
+`ADMultiValue.as_legacy_string(delimiter=None)` reproduces the historic
+delimiter-joined string so existing comma-joined consumers keep working during
+the transition. `ADMultiValue.to_dict()` returns a JSON-serializable payload.
+
+## Deterministic normalization rules
+
+`normalize_multivalue(raw, *, delimiter=",")` is deterministic — the same input
+always yields identical output. The rules:
+
+1. `None` → `values=[]`, `source="absent"`, `normalized=False`.
+2. Empty list `[]` → `values=[]`, `source="list"`, `normalized=True`.
+3. `list` → each element `str(el).strip()`; drop elements that are `None` or empty
+   after strip; **preserve original order and duplicates**; `source="list"`,
+   `normalized=True`.
+4. Non-`str` scalar (e.g. `int`) → `values=[str(raw).strip()]` when non-empty;
+   `source="scalar"`, `normalized=True`.
+5. `str` containing the delimiter → split on the delimiter, `strip()` each, drop
+   empties, preserve order and duplicates; `source="delimited_string"`,
+   `normalized=True`.
+6. `str` without the delimiter → `values=[raw.strip()]` when non-empty else `[]`;
+   `source="scalar"`, `normalized=False`.
+7. `count = len(values)` in all cases.
+
+## Before / after
+
+### Before (legacy comma-joined string — lossy)
+
+```python
+# proxyAddresses came back as ['SMTP:a@x', 'smtp:b@x'] but is flattened to:
+raw_value = "SMTP:a@x,smtp:b@x"
+addresses = raw_value.split(",")  # caller must guess the delimiter
+```
+
+### After (dual-form — raw + normalized + metadata)
+
+```python
+from python_apis.models import normalize_multivalue
+
+mv = normalize_multivalue(["SMTP:a@x", "smtp:b@x"])
+
+mv.raw               # ['SMTP:a@x', 'smtp:b@x'] (verbatim)
+mv.values            # ['SMTP:a@x', 'smtp:b@x'] (normalized list)
+mv.metadata.source   # 'list'
+mv.metadata.count    # 2
+
+# Legacy delimited string is still available during the transition:
+mv.as_legacy_string()  # 'SMTP:a@x,smtp:b@x'
+```
+
+## Notes
+
+- This is purely additive: existing schema fields still return the legacy
+  comma-joined string. Adopt the dual-form incrementally where you need the raw
+  value or structured list.
+- `as_legacy_string()` lets you reproduce the historic representation from the
+  dual-form, so a consumer can migrate to `ADMultiValue` without losing the old
+  string shape.

--- a/examples/multivalue_dual_form.py
+++ b/examples/multivalue_dual_form.py
@@ -1,0 +1,55 @@
+"""Canonical usage example for the AD multivalue dual-form representation (issue #25).
+
+Demonstrates :func:`normalize_multivalue` and :class:`ADMultiValue`, which preserve
+the raw AD source value, expose a deterministically normalized ``list[str]``, and
+carry metadata describing the source kind and normalization status. The legacy
+delimiter-joined string remains available via ``as_legacy_string()`` during the
+transition.
+
+This example imports only the public package surface and needs no AD connection.
+Run with: ``python examples/multivalue_dual_form.py``.
+"""
+
+from python_apis.models import ADMultiValue, normalize_multivalue
+
+
+def print_dual_form(label: str, value: ADMultiValue) -> None:
+    """Print the raw, normalized, and metadata views of a dual-form value."""
+
+    print(f"{label}:")
+    print(f"  raw       = {value.raw!r}")
+    print(f"  values    = {value.values}")
+    print(f"  metadata  = {value.metadata.to_dict()}")
+    print(f"  legacy    = {value.as_legacy_string()!r}")
+
+
+def main() -> None:
+    """Show dual-form handling across the documented source kinds."""
+
+    # True multivalue attribute (list), as ldap3 returns proxyAddresses.
+    print_dual_form(
+        "list source",
+        normalize_multivalue(["SMTP:a@x", "smtp:b@x"]),
+    )
+
+    # Legacy delimited string (already flattened upstream).
+    print_dual_form(
+        "delimited string source",
+        normalize_multivalue("a@x, b@x"),
+    )
+
+    # Single scalar value.
+    print_dual_form(
+        "scalar source",
+        ADMultiValue.from_raw("single-value"),
+    )
+
+    # Absent value.
+    print_dual_form(
+        "absent source",
+        normalize_multivalue(None),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/python_apis/models/__init__.py
+++ b/src/python_apis/models/__init__.py
@@ -18,6 +18,12 @@ from python_apis.models.ad_responses import (
     ADBatchReadResult,
 )
 
+from python_apis.models.multivalue import (
+    ADMultiValue,
+    ADMultiValueMetadata,
+    normalize_multivalue,
+)
+
 from python_apis.models.sap_employee import Employee
 
 from python_apis.models.jira_models import JiraComponent, JiraIssue, JiraRequestType
@@ -35,6 +41,10 @@ __all__ = [
     "ADMembersPage",
     "ADBatchItemFailure",
     "ADBatchReadResult",
+
+    "ADMultiValue",
+    "ADMultiValueMetadata",
+    "normalize_multivalue",
 
     "Employee",
 

--- a/src/python_apis/models/multivalue.py
+++ b/src/python_apis/models/multivalue.py
@@ -1,0 +1,178 @@
+"""Dual-form representation for Active Directory multivalue attributes (issue #25).
+
+Active Directory multivalue attributes (for example ``proxyAddresses``,
+``memberOf``, ``objectClass``) are returned by ldap3 as Python lists. The legacy
+schema path flattens these into a single comma-joined string, which loses the
+raw source value, element boundaries, and ordering metadata.
+
+This module adds an **additive** dual-form representation, :class:`ADMultiValue`,
+that preserves the raw source value, exposes a deterministically normalized
+``list[str]``, and carries :class:`ADMultiValueMetadata` describing the source
+kind and whether normalization was applied. A legacy delimited-string accessor
+(:meth:`ADMultiValue.as_legacy_string`) reproduces the historic comma-joined
+string during the transition.
+
+The normalization rules implemented by :func:`normalize_multivalue` are
+deterministic and documented in ``docs/migration/ad-multivalue-dual-form.md``.
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+DEFAULT_DELIMITER = ","
+
+MultiValueSource = Literal["absent", "list", "scalar", "delimited_string"]
+
+
+class ADMultiValueMetadata(BaseModel):
+    """Metadata describing how an :class:`ADMultiValue` was derived."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: MultiValueSource = Field(
+        description="Kind of the raw source value: absent/list/scalar/delimited_string.",
+    )
+    normalized: bool = Field(
+        description="True when the normalized list was derived/transformed from the raw value.",
+    )
+    count: int = Field(
+        default=0,
+        description="Number of elements in the normalized list.",
+    )
+    delimiter: str = Field(
+        default=DEFAULT_DELIMITER,
+        description="Delimiter used for delimited-string splitting and the legacy accessor.",
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain, JSON-serializable ``dict`` of this metadata."""
+
+        return self.model_dump()
+
+
+class ADMultiValue(BaseModel):
+    """Dual-form view of an AD multivalue attribute (raw + normalized + metadata).
+
+    Exposes the original ``raw`` source value, a deterministically normalized
+    ``values`` list, and ``metadata`` describing the source. Use
+    :meth:`as_legacy_string` to reproduce the historic delimiter-joined string.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    raw: Any = Field(
+        default=None,
+        description="Original source value, preserved verbatim (list/str/int/None).",
+    )
+    values: list[str] = Field(
+        default_factory=list,
+        description="Deterministically normalized list form.",
+    )
+    metadata: ADMultiValueMetadata
+
+    @classmethod
+    def from_raw(
+        cls,
+        raw: Any,
+        *,
+        delimiter: str = DEFAULT_DELIMITER,
+    ) -> "ADMultiValue":
+        """Build an :class:`ADMultiValue` from a raw AD value.
+
+        Thin wrapper over :func:`normalize_multivalue`.
+        """
+
+        return normalize_multivalue(raw, delimiter=delimiter)
+
+    def as_legacy_string(self, delimiter: str | None = None) -> str:
+        """Return the historic delimiter-joined string for the normalized values.
+
+        Reproduces the legacy comma-joined representation so existing consumers
+        can be served from the dual-form during the transition. When
+        ``delimiter`` is ``None`` the delimiter captured in ``metadata`` is used.
+        """
+
+        sep = self.metadata.delimiter if delimiter is None else delimiter
+        return sep.join(self.values)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain, JSON-serializable ``dict`` of this dual-form value."""
+
+        return {
+            "raw": self.raw,
+            "values": list(self.values),
+            "metadata": self.metadata.to_dict(),
+        }
+
+
+def normalize_multivalue(
+    raw: Any,
+    *,
+    delimiter: str = DEFAULT_DELIMITER,
+) -> ADMultiValue:
+    """Build a deterministic dual-form :class:`ADMultiValue` from ``raw``.
+
+    Deterministic normalization rules (same input always yields identical
+    output):
+
+    1. ``None`` -> ``values=[]``, ``source="absent"``, ``normalized=False``.
+    2. Empty list ``[]`` -> ``values=[]``, ``source="list"``, ``normalized=True``.
+    3. ``list`` -> each element ``str(el).strip()``; drop ``None``/empty-after-strip
+       elements; preserve order and duplicates; ``source="list"``,
+       ``normalized=True``.
+    4. Non-``str`` scalar (e.g. ``int``) -> ``values=[str(raw).strip()]`` when
+       non-empty; ``source="scalar"``, ``normalized=True``.
+    5. ``str`` containing ``delimiter`` -> split on ``delimiter``, ``strip()`` each,
+       drop empties, preserve order and duplicates; ``source="delimited_string"``,
+       ``normalized=True``.
+    6. ``str`` without ``delimiter`` -> ``values=[raw.strip()]`` when non-empty else
+       ``[]``; ``source="scalar"``, ``normalized=False``.
+    7. ``count = len(values)`` in all cases.
+
+    Args:
+        raw: The original AD source value (list/str/int/None).
+        delimiter: Delimiter used for delimited-string splitting and recorded in
+            metadata for the legacy accessor.
+
+    Returns:
+        ADMultiValue: The dual-form representation.
+    """
+
+    if raw is None:
+        source: MultiValueSource = "absent"
+        normalized = False
+        values: list[str] = []
+    elif isinstance(raw, list):
+        source = "list"
+        normalized = True
+        values = [
+            stripped
+            for element in raw
+            if element is not None and (stripped := str(element).strip())
+        ]
+    elif isinstance(raw, str):
+        if delimiter in raw:
+            source = "delimited_string"
+            normalized = True
+            values = [
+                part for piece in raw.split(delimiter) if (part := piece.strip())
+            ]
+        else:
+            source = "scalar"
+            normalized = False
+            stripped_scalar = raw.strip()
+            values = [stripped_scalar] if stripped_scalar else []
+    else:
+        source = "scalar"
+        normalized = True
+        stripped_other = str(raw).strip()
+        values = [stripped_other] if stripped_other else []
+
+    metadata = ADMultiValueMetadata(
+        source=source,
+        normalized=normalized,
+        count=len(values),
+        delimiter=delimiter,
+    )
+    return ADMultiValue(raw=raw, values=values, metadata=metadata)

--- a/src/python_apis/models/multivalue.py
+++ b/src/python_apis/models/multivalue.py
@@ -16,6 +16,7 @@ The normalization rules implemented by :func:`normalize_multivalue` are
 deterministic and documented in ``docs/migration/ad-multivalue-dual-form.md``.
 """
 
+from datetime import date, datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -23,6 +24,29 @@ from pydantic import BaseModel, ConfigDict, Field
 DEFAULT_DELIMITER = ","
 
 MultiValueSource = Literal["absent", "list", "scalar", "delimited_string"]
+
+
+def _jsonify(value: Any) -> Any:
+    """Return a JSON-serializable representation of ``value``.
+
+    JSON-native scalars/containers pass through (recursively); ``bytes`` become a
+    hex string, ``datetime``/``date`` become ISO-8601 strings, and any other type
+    falls back to ``str``. This keeps :meth:`ADMultiValue.to_dict` serializable
+    even when a preserved ``raw`` value is a non-JSON-native AD value (for example
+    a binary ``objectGUID`` or a ``datetime``).
+    """
+
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, bytes):
+        return value.hex()
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_jsonify(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _jsonify(item) for key, item in value.items()}
+    return str(value)
 
 
 class ADMultiValueMetadata(BaseModel):
@@ -86,21 +110,39 @@ class ADMultiValue(BaseModel):
         return normalize_multivalue(raw, delimiter=delimiter)
 
     def as_legacy_string(self, delimiter: str | None = None) -> str:
-        """Return the historic delimiter-joined string for the normalized values.
+        """Return the historic legacy delimited-string representation.
 
-        Reproduces the legacy comma-joined representation so existing consumers
-        can be served from the dual-form during the transition. When
-        ``delimiter`` is ``None`` the delimiter captured in ``metadata`` is used.
+        With the default ``delimiter=None`` this reproduces the **historic schema
+        representation derived from** ``raw`` verbatim, matching the legacy
+        behavior existing consumers relied on (``','.join(map(str, value))`` for
+        list sources, the unchanged string for scalar sources, ``str(value)`` for
+        other scalars, and ``''`` when absent). This intentionally does *not*
+        strip/drop elements the way normalization does, so legacy consumers see
+        exactly what the old code produced.
+
+        When an explicit ``delimiter`` is provided, the normalized ``values`` are
+        joined with that separator instead, for callers that want a different
+        delimiter over the cleaned list.
         """
 
-        sep = self.metadata.delimiter if delimiter is None else delimiter
-        return sep.join(self.values)
+        if delimiter is not None:
+            return delimiter.join(self.values)
+        if isinstance(self.raw, list):
+            return DEFAULT_DELIMITER.join(map(str, self.raw)) if self.raw else ""
+        if self.raw is None:
+            return ""
+        return str(self.raw)
 
     def to_dict(self) -> dict[str, Any]:
-        """Return a plain, JSON-serializable ``dict`` of this dual-form value."""
+        """Return a plain, JSON-serializable ``dict`` of this dual-form value.
+
+        The preserved ``raw`` value is converted to a JSON-safe representation
+        (see :func:`_jsonify`) so the payload remains serializable even for
+        non-JSON-native AD values such as binary attributes or datetimes.
+        """
 
         return {
-            "raw": self.raw,
+            "raw": _jsonify(self.raw),
             "values": list(self.values),
             "metadata": self.metadata.to_dict(),
         }
@@ -133,11 +175,18 @@ def normalize_multivalue(
     Args:
         raw: The original AD source value (list/str/int/None).
         delimiter: Delimiter used for delimited-string splitting and recorded in
-            metadata for the legacy accessor.
+            metadata for the legacy accessor. Must be a non-empty string.
 
     Returns:
         ADMultiValue: The dual-form representation.
+
+    Raises:
+        ValueError: If ``delimiter`` is an empty string (``str.split`` rejects an
+            empty separator, so this is reported up front with a clear message).
     """
+
+    if delimiter == "":
+        raise ValueError("delimiter must be a non-empty string")
 
     if raw is None:
         source: MultiValueSource = "absent"

--- a/src/tests/test_models/test_multivalue.py
+++ b/src/tests/test_models/test_multivalue.py
@@ -1,0 +1,152 @@
+# test_multivalue.py
+"""Contract tests for the AD multivalue dual-form representation (issue #25)."""
+
+import sys
+from pathlib import Path
+import unittest
+
+SRC_ROOT = Path(__file__).resolve().parents[2]
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from python_apis.models import (
+    ADMultiValue,
+    ADMultiValueMetadata,
+    normalize_multivalue,
+)
+
+
+class TestNormalizationRules(unittest.TestCase):
+
+    def test_rule1_none_is_absent(self):
+        mv = normalize_multivalue(None)
+        self.assertEqual(mv.values, [])
+        self.assertEqual(mv.metadata.source, 'absent')
+        self.assertFalse(mv.metadata.normalized)
+        self.assertEqual(mv.metadata.count, 0)
+        self.assertIsNone(mv.raw)
+
+    def test_rule2_empty_list(self):
+        mv = normalize_multivalue([])
+        self.assertEqual(mv.values, [])
+        self.assertEqual(mv.metadata.source, 'list')
+        self.assertTrue(mv.metadata.normalized)
+        self.assertEqual(mv.metadata.count, 0)
+
+    def test_rule3_list_strips_drops_empty_preserves_order_and_dupes(self):
+        mv = normalize_multivalue(['  a ', 'b', None, '', 'a'])
+        self.assertEqual(mv.values, ['a', 'b', 'a'])
+        self.assertEqual(mv.metadata.source, 'list')
+        self.assertTrue(mv.metadata.normalized)
+        self.assertEqual(mv.metadata.count, 3)
+        # Raw is preserved verbatim.
+        self.assertEqual(mv.raw, ['  a ', 'b', None, '', 'a'])
+
+    def test_rule3_list_of_ints(self):
+        mv = normalize_multivalue([1, 2, 3])
+        self.assertEqual(mv.values, ['1', '2', '3'])
+        self.assertEqual(mv.metadata.source, 'list')
+
+    def test_rule4_non_str_scalar(self):
+        mv = normalize_multivalue(42)
+        self.assertEqual(mv.values, ['42'])
+        self.assertEqual(mv.metadata.source, 'scalar')
+        self.assertTrue(mv.metadata.normalized)
+        self.assertEqual(mv.metadata.count, 1)
+
+    def test_rule5_delimited_string(self):
+        mv = normalize_multivalue('a, b ,c,')
+        self.assertEqual(mv.values, ['a', 'b', 'c'])
+        self.assertEqual(mv.metadata.source, 'delimited_string')
+        self.assertTrue(mv.metadata.normalized)
+        self.assertEqual(mv.metadata.count, 3)
+
+    def test_rule6_plain_string(self):
+        mv = normalize_multivalue('  hello ')
+        self.assertEqual(mv.values, ['hello'])
+        self.assertEqual(mv.metadata.source, 'scalar')
+        self.assertFalse(mv.metadata.normalized)
+        self.assertEqual(mv.metadata.count, 1)
+
+    def test_rule6_empty_string(self):
+        mv = normalize_multivalue('   ')
+        self.assertEqual(mv.values, [])
+        self.assertEqual(mv.metadata.source, 'scalar')
+        self.assertEqual(mv.metadata.count, 0)
+
+    def test_custom_delimiter(self):
+        mv = normalize_multivalue('a;b;c', delimiter=';')
+        self.assertEqual(mv.values, ['a', 'b', 'c'])
+        self.assertEqual(mv.metadata.source, 'delimited_string')
+        self.assertEqual(mv.metadata.delimiter, ';')
+
+
+class TestDeterminism(unittest.TestCase):
+
+    def test_same_input_same_output(self):
+        raw = ['x', ' y ', 'x']
+        first = normalize_multivalue(raw).to_dict()
+        second = normalize_multivalue(raw).to_dict()
+        self.assertEqual(first, second)
+
+    def test_renormalizing_values_is_idempotent(self):
+        # Re-normalizing the already-normalized list yields the same values.
+        mv = normalize_multivalue(['a', 'b', 'a'])
+        again = normalize_multivalue(mv.values)
+        self.assertEqual(again.values, mv.values)
+
+
+class TestLegacyAccessor(unittest.TestCase):
+
+    def test_as_legacy_string_default_delimiter(self):
+        mv = normalize_multivalue(['a', 'b', 'c'])
+        self.assertEqual(mv.as_legacy_string(), 'a,b,c')
+
+    def test_as_legacy_string_matches_legacy_join(self):
+        # The historic schema behavior was ','.join(map(str, value)).
+        raw = ['a', 'b', 'c']
+        legacy = ','.join(map(str, raw))
+        self.assertEqual(normalize_multivalue(raw).as_legacy_string(), legacy)
+
+    def test_as_legacy_string_custom_delimiter(self):
+        mv = normalize_multivalue(['a', 'b'])
+        self.assertEqual(mv.as_legacy_string(delimiter='|'), 'a|b')
+
+    def test_as_legacy_string_uses_metadata_delimiter(self):
+        mv = normalize_multivalue('a;b', delimiter=';')
+        self.assertEqual(mv.as_legacy_string(), 'a;b')
+
+    def test_empty_legacy_string(self):
+        self.assertEqual(normalize_multivalue(None).as_legacy_string(), '')
+
+
+class TestShapeInvariants(unittest.TestCase):
+
+    def test_from_raw_classmethod(self):
+        mv = ADMultiValue.from_raw(['a', 'b'])
+        self.assertIsInstance(mv, ADMultiValue)
+        self.assertEqual(mv.values, ['a', 'b'])
+
+    def test_to_dict_is_serializable(self):
+        mv = normalize_multivalue(['a', 'b'])
+        payload = mv.to_dict()
+        self.assertEqual(set(payload.keys()), {'raw', 'values', 'metadata'})
+        self.assertEqual(
+            set(payload['metadata'].keys()),
+            {'source', 'normalized', 'count', 'delimiter'},
+        )
+        self.assertEqual(payload['values'], ['a', 'b'])
+
+    def test_count_always_matches_values_length(self):
+        for raw in (None, [], ['a'], ['a', 'b'], 'a,b,c', 'scalar', 7):
+            mv = normalize_multivalue(raw)
+            self.assertEqual(mv.metadata.count, len(mv.values))
+
+    def test_metadata_model_standalone(self):
+        meta = ADMultiValueMetadata(source='list', normalized=True, count=2)
+        self.assertEqual(meta.delimiter, ',')
+        self.assertEqual(meta.to_dict()['source'], 'list')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/test_models/test_multivalue.py
+++ b/src/tests/test_models/test_multivalue.py
@@ -3,6 +3,8 @@
 
 import sys
 from pathlib import Path
+import datetime
+import json
 import unittest
 
 SRC_ROOT = Path(__file__).resolve().parents[2]
@@ -119,6 +121,34 @@ class TestLegacyAccessor(unittest.TestCase):
     def test_empty_legacy_string(self):
         self.assertEqual(normalize_multivalue(None).as_legacy_string(), '')
 
+    def test_as_legacy_string_preserves_raw_verbatim_for_list(self):
+        # Default path reproduces historic ','.join(map(str, value)) without
+        # stripping or dropping empty/None elements (unlike normalization).
+        raw = ['  a ', 'b', None, '', 'a']
+        mv = normalize_multivalue(raw)
+        self.assertEqual(mv.as_legacy_string(), ','.join(map(str, raw)))
+        # Normalized values still drop/strip, proving the two differ.
+        self.assertEqual(mv.values, ['a', 'b', 'a'])
+
+    def test_as_legacy_string_scalar_unchanged(self):
+        mv = normalize_multivalue('single-value')
+        self.assertEqual(mv.as_legacy_string(), 'single-value')
+
+    def test_as_legacy_string_explicit_delimiter_joins_normalized(self):
+        mv = normalize_multivalue(['  a ', 'b', '', 'a'])
+        self.assertEqual(mv.as_legacy_string(delimiter='|'), 'a|b|a')
+
+
+class TestDelimiterValidation(unittest.TestCase):
+
+    def test_empty_delimiter_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            normalize_multivalue('a,b', delimiter='')
+
+    def test_empty_delimiter_raises_via_from_raw(self):
+        with self.assertRaises(ValueError):
+            ADMultiValue.from_raw('a,b', delimiter='')
+
 
 class TestShapeInvariants(unittest.TestCase):
 
@@ -136,6 +166,16 @@ class TestShapeInvariants(unittest.TestCase):
             {'source', 'normalized', 'count', 'delimiter'},
         )
         self.assertEqual(payload['values'], ['a', 'b'])
+
+    def test_to_dict_json_serializable_for_non_native_raw(self):
+        # Binary and datetime raw values must not break json.dumps.
+        for raw in (b'\x00\x01\x02', datetime.datetime(2024, 1, 2, 3, 4, 5)):
+            mv = ADMultiValue.from_raw(raw)
+            json.dumps(mv.to_dict())
+
+    def test_to_dict_serializes_bytes_as_hex(self):
+        mv = ADMultiValue.from_raw(b'\xde\xad')
+        self.assertEqual(mv.to_dict()['raw'], 'dead')
 
     def test_count_always_matches_values_length(self):
         for raw in (None, [], ['a'], ['a', 'b'], 'a,b,c', 'scalar', 7):


### PR DESCRIPTION
## Description

AD multivalue attributes (for example `proxyAddresses`, `memberOf`, `objectClass`) are returned by
ldap3 as Python lists, but the schemas (`ADUserSchema`/`ADGroupSchema`/`ADOrganizationalUnitSchema`)
flatten every list into a single comma-joined string. This is lossy: the raw source value, element
boundaries, and ordering metadata are discarded, and callers cannot distinguish a true multivalue
attribute from a scalar that happens to contain a comma.

This PR adds an **additive** dual-form representation, `ADMultiValue`, that preserves the raw value,
exposes a deterministically normalized `list[str]`, and carries metadata describing the source kind
and normalization status. A legacy delimited-string accessor reproduces the historic comma-joined
string during the transition. Existing schema field types and their comma-joining behavior are
**unchanged**, so the change is purely additive and backward-compatible.

Closes #25

## Changes

- **Models** (`src/python_apis/models/multivalue.py`, exported from `models/__init__.py`):
  - `ADMultiValue` with `raw` (preserved verbatim), `values` (normalized `list[str]`), `metadata`,
    plus `from_raw(...)`, `as_legacy_string(...)`, and a JSON-serializable `to_dict()`.
  - `ADMultiValueMetadata` carrying `source` (`absent`/`list`/`scalar`/`delimited_string`),
    `normalized`, `count`, and `delimiter`.
  - `normalize_multivalue(raw, *, delimiter=",")` — a pure, deterministic helper implementing the
    documented normalization rules.
- **Tests** (`src/tests/test_models/test_multivalue.py`): 20 contract tests covering every
  normalization rule, determinism, legacy-accessor parity, shape invariants, and `to_dict()`
  serializability.
- **Docs/Examples**: migration guide `docs/migration/ad-multivalue-dual-form.md` documenting the
  deterministic normalization rules, and runnable example `examples/multivalue_dual_form.py`.
- **Changelog**: `CHANGELOG.md` Unreleased → Added entry.

## Testing

- `python -m unittest discover -s src/tests -p "test_*.py"` — 254 tests pass.
- `pylint src/python_apis/` — 10.00/10.
- Manual: `python examples/multivalue_dual_form.py` prints raw/normalized/metadata/legacy views for
  list, delimited-string, scalar, and absent sources.

## SemVer

`semver:minor` — additive, backward-compatible (existing schemas and comma-joining behavior
unchanged).
