### PR TITLE
feat(#26): add explicit get_v2 API with typed not-found result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   parity, shape invariants), a migration guide documenting the normalization rules
   (`docs/migration/ad-multivalue-dual-form.md`), and a usage example
   (`examples/multivalue_dual_form.py`)
+- Explicit single-object `get_v2` AD read with a typed not-found result (issue #26):
+  `ADConnection.get_v2(search_filter, attributes)` returns an `ADGetResult` envelope (exported from
+  `python_apis.models`) with an explicit `found` flag, the matched `item`, a deterministic
+  `not_found_reason` (`"no_match"`), and a canonical `error_code` (`"AD_NOT_FOUND"`), so callers can
+  distinguish "absent" from "present but empty". Not-found semantics are deterministic (zero rows →
+  not found; one or more rows → first match). The legacy `ADConnection.get` behavior is unchanged
+  (additive, backward-compatible)
+- Contract tests for `ADGetResult` and `get_v2` (found, first-of-many, not-found, unchanged legacy
+  `get`), a migration guide (`docs/migration/ad-get-v2.md`), and a usage example with a migration
+  helper (`examples/get_v2.py`)
 
 ### Fixed
 

--- a/docs/migration/ad-get-v2.md
+++ b/docs/migration/ad-get-v2.md
@@ -1,0 +1,87 @@
+# Migration Guide: AD `get_v2` Typed Not-Found (Issue #26)
+
+> Status: Additive, non-breaking (SemVer **minor**)
+> Related: [ADR 0001](../adr/0001-ad-response-modernization.md), issue #26
+
+Issue #26 introduces an **additive** single-object read, `ADConnection.get_v2`.
+The legacy `ADConnection.get(search_filter, attributes)` returns the first matched
+object as a `dict`, or an empty `collections.defaultdict(lambda: '')` when nothing
+matches. That empty default is **indistinguishable** from a real object whose
+attributes happen to all be empty, so callers cannot reliably tell "absent" from
+"present but empty".
+
+`get_v2` returns an `ADGetResult` envelope with an explicit `found` flag plus a
+deterministic `not_found_reason`. The legacy `get` is **unchanged**; `get_v2` is
+purely additive.
+
+## What changed
+
+| Legacy method (unchanged) | New v2 method | Returns |
+| --- | --- | --- |
+| `ADConnection.get` | `ADConnection.get_v2` | `ADGetResult` |
+
+## The result envelope
+
+`ADGetResult` (exported from `python_apis.models`) exposes:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `found` | `bool` | `True` when an object matched and is present in `item`. |
+| `item` | `Any` | Matched AD object mapping (first match when several matched); `None` when absent. |
+| `not_found_reason` | `"no_match" \| None` | Deterministic absence reason; `None` when found. |
+| `error_code` | `str \| None` | Canonical taxonomy code for the absence (`"AD_NOT_FOUND"`); `None` when found. |
+
+Constructors: `ADGetResult.found_item(item)` and `ADGetResult.not_found(reason="no_match")`.
+`ADGetResult.to_dict()` returns a plain dict view of the envelope.
+
+## Deterministic not-found semantics
+
+`get_v2` is deterministic — the same search always yields the same envelope shape:
+
+1. Search returns **zero** rows → `found=False`, `item=None`,
+   `not_found_reason="no_match"`, `error_code="AD_NOT_FOUND"`.
+2. Search returns **one or more** rows → `found=True`, `item` is the **first**
+   matched object (matching legacy `get`), `not_found_reason=None`,
+   `error_code=None`.
+
+## Before / after
+
+**Before (legacy, ambiguous):**
+
+```python
+obj = conn.get("(sAMAccountName=jdoe)", ["cn", "sAMAccountName"])
+# Empty default and "present but empty" look identical:
+if obj.get("sAMAccountName"):
+    handle(obj)
+else:
+    handle_missing()  # could be either "absent" or "present but empty"
+```
+
+**After (typed, unambiguous):**
+
+```python
+result = conn.get_v2("(sAMAccountName=jdoe)", ["cn", "sAMAccountName"])
+if result.found:
+    handle(result.item)
+else:
+    handle_missing()  # deterministic: result.not_found_reason == "no_match"
+```
+
+## Migration helper
+
+To adopt `get_v2` at an existing `Optional[dict]` call site with a one-line change,
+wrap it to return the matched mapping or `None`:
+
+```python
+def get_or_none(conn, search_filter, attributes):
+    result = conn.get_v2(search_filter, attributes)
+    return result.item if result.found else None
+```
+
+See [`examples/get_v2.py`](../../examples/get_v2.py) for runnable usage, including a
+connection-free envelope demo and a migration helper.
+
+## SemVer impact
+
+Additive and backward-compatible → **minor**. The legacy `get` keeps its exact
+behavior; no existing call site needs to change.

--- a/examples/get_v2.py
+++ b/examples/get_v2.py
@@ -1,0 +1,77 @@
+"""Canonical usage example and migration helpers for the AD ``get_v2`` API (issue #26).
+
+The legacy single-object read ``ADConnection.get`` returns the first matched
+object as a ``dict`` or an empty ``collections.defaultdict`` when nothing matches.
+That empty default is indistinguishable from a real object whose attributes are
+all empty, so callers cannot reliably tell "absent" from "present but empty".
+
+``ADConnection.get_v2`` is the additive, typed counterpart: it returns an
+``ADGetResult`` envelope with an explicit ``found`` flag and a deterministic
+``not_found_reason``. The legacy ``get`` behavior is unchanged.
+
+The ``demo_envelope`` function below runs with no AD connection. The connection
+based functions assume the standard in-domain AD environment variables
+(``LDAP_SERVER_LIST``, ``SEARCH_BASE``) are configured; see the project README.
+Run with: ``python examples/get_v2.py``.
+"""
+
+from python_apis.apis import ADConnection
+from python_apis.models import ADGetResult
+
+
+def demo_envelope() -> None:
+    """Show the dual found/not-found shape without needing an AD connection."""
+
+    found = ADGetResult.found_item({"sAMAccountName": "jdoe", "cn": "John Doe"})
+    print("found:")
+    print(f"  found             = {found.found}")
+    print(f"  item              = {found.item}")
+    print(f"  not_found_reason  = {found.not_found_reason}")
+    print(f"  to_dict()         = {found.to_dict()}")
+
+    absent = ADGetResult.not_found()
+    print("absent:")
+    print(f"  found             = {absent.found}")
+    print(f"  item              = {absent.item}")
+    print(f"  not_found_reason  = {absent.not_found_reason}")
+    print(f"  error_code        = {absent.error_code}")
+    print(f"  to_dict()         = {absent.to_dict()}")
+
+
+def get_v2_usage(conn: ADConnection, search_filter: str) -> None:
+    """Branch on the explicit ``found`` flag instead of probing dict keys."""
+
+    result = conn.get_v2(search_filter, ["cn", "sAMAccountName"])
+    if result.found:
+        print(f"found object: {result.item}")
+    else:
+        # Deterministic absence: no_match -> AD_NOT_FOUND.
+        print(f"not found ({result.not_found_reason}, {result.error_code})")
+
+
+def migrate_get_callsite(conn: ADConnection, search_filter: str) -> dict | None:
+    """Migration helper: replace ``conn.get(...)`` with an explicit Optional.
+
+    Legacy callers wrote::
+
+        obj = conn.get(search_filter, attrs)
+        if obj.get("sAMAccountName"):   # ambiguous: empty default vs empty attr
+            ...
+
+    With ``get_v2`` the presence check is unambiguous. This helper returns the
+    matched mapping or ``None``, so existing ``Optional[dict]`` consumers can adopt
+    the typed API with a one-line change.
+    """
+
+    result = conn.get_v2(search_filter, ["cn", "sAMAccountName"])
+    return result.item if result.found else None
+
+
+def main() -> None:
+    """Run the connection-free envelope demo."""
+
+    demo_envelope()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/python_apis/apis/ad_api.py
+++ b/src/python_apis/apis/ad_api.py
@@ -21,6 +21,8 @@ from ldap3 import (ALL_ATTRIBUTES, BASE, MODIFY_ADD, MODIFY_DELETE,
                    Connection, Server, ServerPool, Tls)
 from ldap3.core.exceptions import LDAPCommunicationError, LDAPSessionTerminatedByServerError
 
+from python_apis.models.ad_get import ADGetResult
+
 logger = logging.getLogger(__name__)
 
 _RECOVERABLE_EXCEPTIONS = (LDAPSessionTerminatedByServerError, LDAPCommunicationError)
@@ -307,6 +309,35 @@ class ADConnection:
 
         search_result = self.search(search_filter, attributes)
         return search_result[0] if len(search_result) > 0 else collections.defaultdict(lambda: '')
+
+    def get_v2(
+        self, search_filter: str, attributes: list[str] | None = None
+    ) -> ADGetResult:
+        """Typed, found/not-found-aware counterpart of :meth:`get`.
+
+        Unlike :meth:`get`, which returns an empty ``defaultdict`` when nothing
+        matches (indistinguishable from a real object whose attributes are all
+        empty), this returns an :class:`ADGetResult` envelope with an explicit
+        ``found`` flag and a deterministic ``not_found_reason`` so callers can
+        tell "absent" from "present but empty". The legacy :meth:`get` is
+        unchanged.
+
+        Not-found semantics are deterministic: a search returning zero rows
+        yields ``found=False`` with ``not_found_reason="no_match"``. When several
+        rows match, the first is returned as ``found=True`` (matching :meth:`get`).
+
+        Args:
+            search_filter (str): An LDAP filter string.
+            attributes (list[str]): A list of attributes that will be fetched.
+
+        Returns:
+            ADGetResult: A typed found/not-found envelope.
+        """
+
+        search_result = self.search(search_filter, attributes)
+        if search_result:
+            return ADGetResult.found_item(search_result[0])
+        return ADGetResult.not_found()
 
     @staticmethod
     def _parse_ranged_attribute(

--- a/src/python_apis/apis/ad_api.py
+++ b/src/python_apis/apis/ad_api.py
@@ -328,7 +328,8 @@ class ADConnection:
 
         Args:
             search_filter (str): An LDAP filter string.
-            attributes (list[str]): A list of attributes that will be fetched.
+            attributes (list[str] | None): Attributes to fetch; ``None`` fetches
+                ``ALL_ATTRIBUTES``.
 
         Returns:
             ADGetResult: A typed found/not-found envelope.

--- a/src/python_apis/models/__init__.py
+++ b/src/python_apis/models/__init__.py
@@ -16,8 +16,9 @@ from python_apis.models.ad_responses import (
     ADMembersPage,
     ADBatchItemFailure,
     ADBatchReadResult,
-    ADGetResult,
 )
+
+from python_apis.models.ad_get import ADGetResult
 
 from python_apis.models.multivalue import (
     ADMultiValue,

--- a/src/python_apis/models/__init__.py
+++ b/src/python_apis/models/__init__.py
@@ -16,6 +16,7 @@ from python_apis.models.ad_responses import (
     ADMembersPage,
     ADBatchItemFailure,
     ADBatchReadResult,
+    ADGetResult,
 )
 
 from python_apis.models.multivalue import (
@@ -41,6 +42,7 @@ __all__ = [
     "ADMembersPage",
     "ADBatchItemFailure",
     "ADBatchReadResult",
+    "ADGetResult",
 
     "ADMultiValue",
     "ADMultiValueMetadata",

--- a/src/python_apis/models/ad_get.py
+++ b/src/python_apis/models/ad_get.py
@@ -18,7 +18,7 @@ so ``ADConnection`` cannot import from that module).
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 # Mirrors ``python_apis.services.error_taxonomy.AD_NOT_FOUND``. Duplicated here as a
 # plain string because the services constant cannot be imported without a circular
@@ -41,9 +41,9 @@ class ADGetResult(BaseModel):
     found: bool = Field(
         description="True when an object matched and is present in ``item``.",
     )
-    item: Any = Field(
+    item: dict[str, Any] | None = Field(
         default=None,
-        description="Matched AD object (first match when several matched); None when absent.",
+        description="Matched AD object mapping (first match when several); None when absent.",
     )
     not_found_reason: ADGetNotFoundReason | None = Field(
         default=None,
@@ -54,8 +54,29 @@ class ADGetResult(BaseModel):
         description="Canonical error taxonomy code for the absence, e.g. 'AD_NOT_FOUND'.",
     )
 
+    @model_validator(mode="after")
+    def _check_found_invariants(self) -> "ADGetResult":
+        """Reject internally inconsistent envelopes.
+
+        A found result must carry an ``item`` and no absence metadata; a
+        not-found result must omit ``item`` and carry a ``not_found_reason``.
+        Validating at construction keeps this public contract type unambiguous.
+        """
+
+        if self.found:
+            if self.item is None:
+                raise ValueError("found result requires a non-None item")
+            if self.not_found_reason is not None or self.error_code is not None:
+                raise ValueError("found result must not carry not-found metadata")
+        else:
+            if self.item is not None:
+                raise ValueError("not-found result must not carry an item")
+            if self.not_found_reason is None:
+                raise ValueError("not-found result requires a not_found_reason")
+        return self
+
     @classmethod
-    def found_item(cls, item: Any) -> "ADGetResult":
+    def found_item(cls, item: dict[str, Any]) -> "ADGetResult":
         """Build a found result wrapping ``item``."""
 
         return cls(found=True, item=item)

--- a/src/python_apis/models/ad_get.py
+++ b/src/python_apis/models/ad_get.py
@@ -1,0 +1,88 @@
+"""Typed found/not-found envelope for single-object AD reads (issue #26).
+
+The legacy single-object read ``python_apis.apis.ad_api.ADConnection.get`` returns
+the first matched object as a ``dict`` or an empty ``defaultdict`` when nothing
+matches. That empty default is indistinguishable from a real object whose
+attributes are all empty, so callers cannot reliably tell "absent" from "present
+but empty".
+
+This module adds an **additive** typed envelope, :class:`ADGetResult`, returned by
+the ``get_v2`` counterpart. It carries an explicit ``found`` flag plus a
+deterministic ``not_found_reason`` so absence is unambiguous. The legacy ``get``
+behavior is unchanged.
+
+This module intentionally depends only on ``pydantic`` so the API layer can import
+it without a circular import (``models.ad_responses`` lazily imports the API layer,
+so ``ADConnection`` cannot import from that module).
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Mirrors ``python_apis.services.error_taxonomy.AD_NOT_FOUND``. Duplicated here as a
+# plain string because the services constant cannot be imported without a circular
+# import (``services/__init__`` imports the AD services, which import the API layer).
+AD_NOT_FOUND_CODE = "AD_NOT_FOUND"
+
+ADGetNotFoundReason = Literal["no_match"]
+
+
+class ADGetResult(BaseModel):
+    """Typed found/not-found envelope returned by single-object ``get_v2`` reads.
+
+    Carries an explicit ``found`` flag plus a deterministic ``not_found_reason`` so
+    callers can reliably distinguish "absent" from "present but empty", unlike the
+    legacy ``get`` which returns an empty mapping for both.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    found: bool = Field(
+        description="True when an object matched and is present in ``item``.",
+    )
+    item: Any = Field(
+        default=None,
+        description="Matched AD object (first match when several matched); None when absent.",
+    )
+    not_found_reason: ADGetNotFoundReason | None = Field(
+        default=None,
+        description="Deterministic absence reason, e.g. 'no_match'. None when found.",
+    )
+    error_code: str | None = Field(
+        default=None,
+        description="Canonical error taxonomy code for the absence, e.g. 'AD_NOT_FOUND'.",
+    )
+
+    @classmethod
+    def found_item(cls, item: Any) -> "ADGetResult":
+        """Build a found result wrapping ``item``."""
+
+        return cls(found=True, item=item)
+
+    @classmethod
+    def not_found(cls, reason: ADGetNotFoundReason = "no_match") -> "ADGetResult":
+        """Build a not-found result with a deterministic ``reason`` and error code."""
+
+        return cls(found=False, not_found_reason=reason, error_code=AD_NOT_FOUND_CODE)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain ``dict`` view of this result.
+
+        ``item`` is included as-is: for ``get_v2`` it is the raw AD object mapping
+        (or ``None`` when absent), which is already a plain ``dict``.
+        """
+
+        return {
+            "found": self.found,
+            "item": self.item,
+            "not_found_reason": self.not_found_reason,
+            "error_code": self.error_code,
+        }
+
+
+__all__ = [
+    "ADGetResult",
+    "ADGetNotFoundReason",
+    "AD_NOT_FOUND_CODE",
+]

--- a/src/python_apis/models/ad_responses.py
+++ b/src/python_apis/models/ad_responses.py
@@ -429,81 +429,6 @@ class ADBatchReadResult(BaseModel):
         }
 
 
-# Mirrors ``python_apis.services.error_taxonomy.AD_NOT_FOUND``. Duplicated here as a
-# string literal because the models layer cannot import the services constant without
-# a circular import (``services/__init__`` imports the AD services, which import this
-# models layer).
-_AD_NOT_FOUND_CODE = "AD_NOT_FOUND"
-
-ADGetNotFoundReason = Literal["no_match"]
-
-
-class ADGetResult(BaseModel):
-    """Typed found/not-found envelope returned by single-object ``get_v2`` reads.
-
-    The legacy ``ADConnection.get`` returns the first matched object as a ``dict``
-    or an empty ``defaultdict`` when nothing matches, which is indistinguishable
-    from a real object whose attributes are all empty. This envelope instead
-    carries an explicit ``found`` flag plus a deterministic ``not_found_reason`` so
-    callers can reliably tell "absent" from "present but empty".
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    found: bool = Field(
-        description="True when an object matched and is present in ``item``.",
-    )
-    item: Any = Field(
-        default=None,
-        description="The matched AD object (first match when several matched); None when absent.",
-    )
-    not_found_reason: ADGetNotFoundReason | None = Field(
-        default=None,
-        description="Deterministic reason the object was absent, e.g. 'no_match'. None when found.",
-    )
-    error_code: str | None = Field(
-        default=None,
-        description="Canonical error taxonomy code for the absence, e.g. 'AD_NOT_FOUND'. None when found.",
-    )
-
-    @classmethod
-    def found_item(cls, item: Any) -> "ADGetResult":
-        """Build a found result wrapping ``item``."""
-
-        return cls(found=True, item=item)
-
-    @classmethod
-    def not_found(
-        cls, reason: ADGetNotFoundReason = "no_match"
-    ) -> "ADGetResult":
-        """Build a not-found result with a deterministic ``reason`` and error code."""
-
-        return cls(
-            found=False,
-            not_found_reason=reason,
-            error_code=_AD_NOT_FOUND_CODE,
-        )
-
-    def to_dict(self) -> dict[str, Any]:
-        """Return a plain, JSON-serializable ``dict`` of this result."""
-
-        item = self.item
-        to_dict = getattr(item, "to_dict", None)
-        if callable(to_dict):
-            item = to_dict()
-        else:
-            mapped = _sqlalchemy_to_dict(item)
-            if mapped is not None:
-                item = mapped
-
-        return {
-            "found": self.found,
-            "item": item,
-            "not_found_reason": self.not_found_reason,
-            "error_code": self.error_code,
-        }
-
-
 __all__: list[str] = [
     # pylint: disable=duplicate-code
     "ADResponse",
@@ -514,5 +439,4 @@ __all__: list[str] = [
     "ADMembersPage",
     "ADBatchItemFailure",
     "ADBatchReadResult",
-    "ADGetResult",
 ]

--- a/src/python_apis/models/ad_responses.py
+++ b/src/python_apis/models/ad_responses.py
@@ -429,6 +429,81 @@ class ADBatchReadResult(BaseModel):
         }
 
 
+# Mirrors ``python_apis.services.error_taxonomy.AD_NOT_FOUND``. Duplicated here as a
+# string literal because the models layer cannot import the services constant without
+# a circular import (``services/__init__`` imports the AD services, which import this
+# models layer).
+_AD_NOT_FOUND_CODE = "AD_NOT_FOUND"
+
+ADGetNotFoundReason = Literal["no_match"]
+
+
+class ADGetResult(BaseModel):
+    """Typed found/not-found envelope returned by single-object ``get_v2`` reads.
+
+    The legacy ``ADConnection.get`` returns the first matched object as a ``dict``
+    or an empty ``defaultdict`` when nothing matches, which is indistinguishable
+    from a real object whose attributes are all empty. This envelope instead
+    carries an explicit ``found`` flag plus a deterministic ``not_found_reason`` so
+    callers can reliably tell "absent" from "present but empty".
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    found: bool = Field(
+        description="True when an object matched and is present in ``item``.",
+    )
+    item: Any = Field(
+        default=None,
+        description="The matched AD object (first match when several matched); None when absent.",
+    )
+    not_found_reason: ADGetNotFoundReason | None = Field(
+        default=None,
+        description="Deterministic reason the object was absent, e.g. 'no_match'. None when found.",
+    )
+    error_code: str | None = Field(
+        default=None,
+        description="Canonical error taxonomy code for the absence, e.g. 'AD_NOT_FOUND'. None when found.",
+    )
+
+    @classmethod
+    def found_item(cls, item: Any) -> "ADGetResult":
+        """Build a found result wrapping ``item``."""
+
+        return cls(found=True, item=item)
+
+    @classmethod
+    def not_found(
+        cls, reason: ADGetNotFoundReason = "no_match"
+    ) -> "ADGetResult":
+        """Build a not-found result with a deterministic ``reason`` and error code."""
+
+        return cls(
+            found=False,
+            not_found_reason=reason,
+            error_code=_AD_NOT_FOUND_CODE,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain, JSON-serializable ``dict`` of this result."""
+
+        item = self.item
+        to_dict = getattr(item, "to_dict", None)
+        if callable(to_dict):
+            item = to_dict()
+        else:
+            mapped = _sqlalchemy_to_dict(item)
+            if mapped is not None:
+                item = mapped
+
+        return {
+            "found": self.found,
+            "item": item,
+            "not_found_reason": self.not_found_reason,
+            "error_code": self.error_code,
+        }
+
+
 __all__: list[str] = [
     # pylint: disable=duplicate-code
     "ADResponse",
@@ -439,4 +514,5 @@ __all__: list[str] = [
     "ADMembersPage",
     "ADBatchItemFailure",
     "ADBatchReadResult",
+    "ADGetResult",
 ]

--- a/src/tests/test_apis/test_ad_api.py
+++ b/src/tests/test_apis/test_ad_api.py
@@ -90,6 +90,50 @@ class TestADConnection(unittest.TestCase):
 
         self.assertEqual(result['cn'], '')  # defaultdict returns empty string
 
+    def test_get_v2_with_results(self):
+        ad_conn = ADConnection(self.servers, self.search_base)
+        mock_result = [{'attributes': {'cn': 'John Doe'}}]
+        self.mock_connection.extend.standard.paged_search.return_value = iter(mock_result)
+
+        result = ad_conn.get_v2('(objectClass=user)', ['cn'])
+
+        self.assertTrue(result.found)
+        self.assertEqual(result.item['cn'], 'John Doe')
+        self.assertIsNone(result.not_found_reason)
+        self.assertIsNone(result.error_code)
+
+    def test_get_v2_returns_first_of_many(self):
+        ad_conn = ADConnection(self.servers, self.search_base)
+        mock_result = [
+            {'attributes': {'cn': 'First'}},
+            {'attributes': {'cn': 'Second'}},
+        ]
+        self.mock_connection.extend.standard.paged_search.return_value = iter(mock_result)
+
+        result = ad_conn.get_v2('(objectClass=user)', ['cn'])
+
+        self.assertTrue(result.found)
+        self.assertEqual(result.item['cn'], 'First')
+
+    def test_get_v2_no_results(self):
+        ad_conn = ADConnection(self.servers, self.search_base)
+        self.mock_connection.extend.standard.paged_search.return_value = iter([])
+
+        result = ad_conn.get_v2('(objectClass=user)', ['cn'])
+
+        self.assertFalse(result.found)
+        self.assertIsNone(result.item)
+        self.assertEqual(result.not_found_reason, 'no_match')
+        self.assertEqual(result.error_code, 'AD_NOT_FOUND')
+
+    def test_get_v2_does_not_change_legacy_get(self):
+        ad_conn = ADConnection(self.servers, self.search_base)
+        self.mock_connection.extend.standard.paged_search.return_value = iter([])
+
+        # Legacy get still returns an empty-default mapping, not an ADGetResult.
+        legacy = ad_conn.get('(objectClass=user)', ['cn'])
+        self.assertEqual(legacy['cn'], '')
+
     def test_modify(self):
         ad_conn = ADConnection(self.servers, self.search_base)
         distinguished_name = 'cn=John Doe,ou=users,dc=example,dc=com'

--- a/src/tests/test_models/test_ad_get_result.py
+++ b/src/tests/test_models/test_ad_get_result.py
@@ -1,0 +1,71 @@
+# test_ad_get_result.py
+"""Contract tests for the AD single-object get_v2 result envelope (issue #26)."""
+
+import sys
+from pathlib import Path
+import json
+import unittest
+
+SRC_ROOT = Path(__file__).resolve().parents[2]
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from python_apis.models import ADGetResult
+from python_apis.models.ad_get import AD_NOT_FOUND_CODE
+
+
+class TestADGetResultConstructors(unittest.TestCase):
+
+    def test_found_item(self):
+        item = {'sAMAccountName': 'jdoe', 'cn': 'John Doe'}
+        result = ADGetResult.found_item(item)
+        self.assertTrue(result.found)
+        self.assertEqual(result.item, item)
+        self.assertIsNone(result.not_found_reason)
+        self.assertIsNone(result.error_code)
+
+    def test_not_found_defaults_to_no_match(self):
+        result = ADGetResult.not_found()
+        self.assertFalse(result.found)
+        self.assertIsNone(result.item)
+        self.assertEqual(result.not_found_reason, 'no_match')
+        self.assertEqual(result.error_code, AD_NOT_FOUND_CODE)
+
+    def test_not_found_error_code_is_canonical(self):
+        self.assertEqual(AD_NOT_FOUND_CODE, 'AD_NOT_FOUND')
+
+    def test_not_found_error_code_mirrors_taxonomy(self):
+        # The duplicated literal must stay in sync with the services taxonomy.
+        from python_apis.services.error_taxonomy import AD_NOT_FOUND
+        self.assertEqual(AD_NOT_FOUND_CODE, AD_NOT_FOUND)
+
+
+class TestADGetResultShape(unittest.TestCase):
+
+    def test_to_dict_found_is_json_serializable(self):
+        result = ADGetResult.found_item({'cn': 'John Doe'})
+        payload = result.to_dict()
+        self.assertEqual(
+            set(payload.keys()),
+            {'found', 'item', 'not_found_reason', 'error_code'},
+        )
+        self.assertTrue(payload['found'])
+        self.assertEqual(payload['item'], {'cn': 'John Doe'})
+        json.dumps(payload)
+
+    def test_to_dict_not_found_is_json_serializable(self):
+        payload = ADGetResult.not_found().to_dict()
+        self.assertFalse(payload['found'])
+        self.assertIsNone(payload['item'])
+        self.assertEqual(payload['not_found_reason'], 'no_match')
+        self.assertEqual(payload['error_code'], 'AD_NOT_FOUND')
+        json.dumps(payload)
+
+    def test_extra_fields_forbidden(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            ADGetResult(found=True, item={}, unexpected='x')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/test_models/test_ad_get_result.py
+++ b/src/tests/test_models/test_ad_get_result.py
@@ -67,5 +67,28 @@ class TestADGetResultShape(unittest.TestCase):
             ADGetResult(found=True, item={}, unexpected='x')
 
 
+class TestADGetResultInvariants(unittest.TestCase):
+
+    def test_found_true_requires_item(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            ADGetResult(found=True, item=None)
+
+    def test_found_true_rejects_not_found_metadata(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            ADGetResult(found=True, item={'cn': 'x'}, not_found_reason='no_match')
+
+    def test_found_false_rejects_item(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            ADGetResult(found=False, item={'cn': 'x'}, not_found_reason='no_match')
+
+    def test_found_false_requires_reason(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            ADGetResult(found=False, item=None)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

The legacy single-object AD read `ADConnection.get(search_filter, attributes)` returns the first matched object as a `dict`, or an empty `collections.defaultdict(lambda: '')` when nothing matches. That empty default is **indistinguishable** from a real object whose attributes happen to all be empty, so callers cannot reliably tell "absent" from "present but empty".

This PR adds an **additive**, typed counterpart, `ADConnection.get_v2`, that returns an `ADGetResult` envelope with an explicit `found` flag plus a deterministic `not_found_reason`. The legacy `get` behavior is **unchanged**, so the change is purely additive and backward-compatible.

Closes #26

## Changes

- **Model** (`src/python_apis/models/ad_get.py`, exported from `models/__init__.py`):
  - `ADGetResult` with `found`, `item`, `not_found_reason`, and `error_code`, plus `found_item(...)` / `not_found(...)` constructors and a plain `to_dict()`.
  - Lives in its own pydantic-only module so the API layer can import it without a circular import (`models.ad_responses` lazily imports the API layer).
- **API** (`src/python_apis/apis/ad_api.py`):
  - `ADConnection.get_v2(search_filter, attributes)` reuses `search(...)` and returns `ADGetResult.found_item(first)` when results exist, else `ADGetResult.not_found()`. Legacy `get` is untouched.
- **Tests**:
  - `src/tests/test_models/test_ad_get_result.py` — constructors, `to_dict` JSON-serializability, `extra="forbid"`, and a guard that `AD_NOT_FOUND` stays in sync with `services.error_taxonomy.AD_NOT_FOUND`.
  - `src/tests/test_apis/test_ad_api.py` — `get_v2` found, first-of-many, not-found, and unchanged legacy `get`.
- **Docs/Examples**:
  - `docs/migration/ad-get-v2.md` — contract, deterministic not-found rules, before/after, migration helper.
  - `examples/get_v2.py` — runnable connection-free envelope demo plus a migration helper.
- **CHANGELOG.md** — Unreleased → Added entry.

### Deterministic not-found semantics

- Search returns **zero** rows → `found=False`, `item=None`, `not_found_reason="no_match"`, `error_code="AD_NOT_FOUND"`.
- Search returns **one or more** rows → `found=True`, `item` is the **first** match (matching legacy `get`), `not_found_reason=None`, `error_code=None`.

## Testing

- `python -m pylint src/python_apis/` → **10.00/10**
- `python -m unittest discover -s src/tests -p "test_*.py"` → **272 passing**
- `python examples/get_v2.py` → prints the found and not-found envelopes

## SemVer

`semver:minor` — additive, backward-compatible. The legacy `ADConnection.get` keeps its exact behavior; no existing call site needs to change.