### PR TITLE
feat(#27): add in-package AD discoverability toolkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- In-package discoverability toolkit for the modernized AD surface (issue #27): `python_apis.discovery` (capability registry via `list_capabilities`/`get_capability`, compatibility-mode introspection via `active_compatibility_mode`/`describe_compatibility_modes`, and a printable `quick_reference`), `python_apis.deprecation` (`warn_legacy` structured migration warnings, now emitted by legacy `ADConnection.get`), and `python_apis.migration_examples` (connection-free before/after snippets). All additive (`semver:minor`).
 - rename_user_cn functionality to ADUserService for renaming user common names
 - Python 3.14 support and optimized CI/CD workflows  
 - Comprehensive test coverage (100% function coverage with 48 tests)

--- a/src/python_apis/__init__.py
+++ b/src/python_apis/__init__.py
@@ -12,15 +12,30 @@ Available submodules:
     data integrity.
 - **services**: Offers service classes that encapsulate business logic and orchestrate interactions
     between APIs and models.
+- **discovery**: Machine-readable registry of modern AD capabilities plus compatibility-mode
+    introspection and a quick-reference summary.
+- **deprecation**: Structured ``warn_legacy`` helper that emits actionable migration hints.
+- **migration_examples**: Connection-free before/after code snippets for adopting modern APIs.
 
 By importing this package, these main submodules are made available for convenient access and use
 in other parts of the application.
 """
 
-from python_apis import apis, models, schemas, services
+from python_apis import (
+    apis,
+    deprecation,
+    discovery,
+    migration_examples,
+    models,
+    schemas,
+    services,
+)
 
 __all__ = [
     "apis",
+    "deprecation",
+    "discovery",
+    "migration_examples",
     "models",
     "schemas",
     "services",

--- a/src/python_apis/apis/ad_api.py
+++ b/src/python_apis/apis/ad_api.py
@@ -21,6 +21,7 @@ from ldap3 import (ALL_ATTRIBUTES, BASE, MODIFY_ADD, MODIFY_DELETE,
                    Connection, Server, ServerPool, Tls)
 from ldap3.core.exceptions import LDAPCommunicationError, LDAPSessionTerminatedByServerError
 
+from python_apis.deprecation import warn_legacy
 from python_apis.models.ad_get import ADGetResult
 
 logger = logging.getLogger(__name__)
@@ -299,14 +300,43 @@ class ADConnection:
         """Returns a single result, the first result if more then one result
         is matched and an empty dict if zero results where returned.
 
+        .. deprecated::
+            Prefer :meth:`get_v2`, which returns a typed :class:`ADGetResult`
+            with an explicit ``found`` flag. The legacy empty-default mapping is
+            indistinguishable from a real object whose attributes are all empty.
+
+            Before (legacy, ambiguous)::
+
+                obj = conn.get("(sAMAccountName=jdoe)", ["cn"])
+                if obj.get("cn"):   # empty default vs present-but-empty
+                    ...
+
+            After (typed, unambiguous)::
+
+                res = conn.get_v2("(sAMAccountName=jdoe)", ["cn"])
+                if res.found:
+                    use(res.item)
+
+            See ``python_apis.discovery.get_capability('get-v2')`` and
+            ``python_apis.migration_examples.legacy_get_to_get_v2()``.
+
         Args:
             search_filter (str): An LDAP filter string.
-            attributes (list[str]): A list of attributes that will be fetched.
+            attributes (list[str] | None): Attributes to fetch; ``None`` fetches
+                ``ALL_ATTRIBUTES``.
 
         Returns:
             dict[str, str]: AD object as a dict, empty values if none were found.
         """
 
+        warn_legacy(
+            "ADConnection.get",
+            replacement="ADConnection.get_v2",
+            migration_hint=(
+                "Branch on ADGetResult.found instead of probing the empty default "
+                "mapping; see python_apis.discovery.get_capability('get-v2')."
+            ),
+        )
         search_result = self.search(search_filter, attributes)
         return search_result[0] if len(search_result) > 0 else collections.defaultdict(lambda: '')
 

--- a/src/python_apis/deprecation.py
+++ b/src/python_apis/deprecation.py
@@ -1,0 +1,93 @@
+"""Structured deprecation warnings with actionable migration hints (issue #27).
+
+Modernized AD behaviors are additive: legacy entry points keep working, but a
+structured :class:`DeprecationWarning` points callers at the modern replacement
+so the migration is discoverable at runtime. The warning text alone names the
+legacy symbol, its replacement, and a concrete migration hint, so no external
+docs are required to act on it.
+
+Example:
+    >>> import warnings
+    >>> from python_apis.deprecation import warn_legacy
+    >>> with warnings.catch_warnings(record=True) as caught:
+    ...     warnings.simplefilter("always")
+    ...     msg = warn_legacy(
+    ...         "ADConnection.get",
+    ...         replacement="ADConnection.get_v2",
+    ...         migration_hint="Branch on result.found instead of an empty mapping.",
+    ...     )
+    >>> "ADConnection.get_v2" in msg
+    True
+"""
+
+import warnings
+
+
+def build_legacy_message(
+    legacy: str,
+    *,
+    replacement: str,
+    migration_hint: str,
+    since: str | None = None,
+) -> str:
+    """Build a single-line, actionable legacy-migration message.
+
+    Args:
+        legacy: The legacy symbol being used (for example ``"ADConnection.get"``).
+        replacement: The modern replacement symbol to adopt.
+        migration_hint: A concrete, actionable hint describing the change.
+        since: Optional version/issue marker for when ``legacy`` was superseded.
+
+    Returns:
+        The composed message string.
+    """
+
+    since_part = f" (since {since})" if since else ""
+    return (
+        f"{legacy} is legacy{since_part}; use {replacement} instead. "
+        f"Migration: {migration_hint}"
+    )
+
+
+def warn_legacy(
+    legacy: str,
+    *,
+    replacement: str,
+    migration_hint: str,
+    since: str | None = None,
+    category: type[Warning] = DeprecationWarning,
+    stacklevel: int = 2,
+) -> str:
+    """Emit a structured legacy-migration warning and return its message.
+
+    The emitted warning carries the same text returned by
+    :func:`build_legacy_message`, so the migration is actionable from the
+    warning alone. The call is purely informational and does not change the
+    behavior of the legacy code path.
+
+    Args:
+        legacy: The legacy symbol being used.
+        replacement: The modern replacement symbol to adopt.
+        migration_hint: A concrete, actionable migration hint.
+        since: Optional version/issue marker for when ``legacy`` was superseded.
+        category: Warning category to emit (default :class:`DeprecationWarning`).
+        stacklevel: Stack level so the warning points at the caller's call site.
+
+    Returns:
+        The warning message that was emitted.
+    """
+
+    message = build_legacy_message(
+        legacy,
+        replacement=replacement,
+        migration_hint=migration_hint,
+        since=since,
+    )
+    warnings.warn(message, category=category, stacklevel=stacklevel + 1)
+    return message
+
+
+__all__ = [
+    "build_legacy_message",
+    "warn_legacy",
+]

--- a/src/python_apis/deprecation.py
+++ b/src/python_apis/deprecation.py
@@ -49,7 +49,7 @@ def build_legacy_message(
     )
 
 
-def warn_legacy(
+def warn_legacy(  # pylint: disable=too-many-arguments
     legacy: str,
     *,
     replacement: str,

--- a/src/python_apis/discovery.py
+++ b/src/python_apis/discovery.py
@@ -1,0 +1,354 @@
+"""In-package discoverability toolkit for modernized AD behavior (issue #27).
+
+This module lets users and agents understand the modernized, additive AD
+behaviors **from the Python REPL and IDE hints alone**, without visiting the
+GitHub docs under ``docs/migration/`` or ``docs/adr/``.
+
+It provides:
+
+* A runtime **capability registry** describing each modernized behavior, its
+  public entry points, and its legacy-to-v2 migration note
+  (:func:`list_capabilities`, :func:`get_capability`).
+* **Compatibility-mode introspection** (:func:`active_compatibility_mode`,
+  :func:`describe_compatibility_modes`).
+* A printable **quick reference** cheat sheet (:func:`quick_reference`,
+  :func:`print_quick_reference`).
+
+Everything here is pure Python over already-public names; calling any function
+needs no AD connection and adds no new dependencies.
+
+Example:
+    >>> from python_apis import discovery
+    >>> discovery.active_compatibility_mode()
+    'legacy'
+    >>> names = [cap["name"] for cap in discovery.list_capabilities()]
+    >>> "get-v2" in names
+    True
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+from python_apis.apis import (
+    AD_COMPATIBILITY_ENV_VAR,
+    AD_COMPATIBILITY_MODES,
+    AD_DEFAULT_COMPATIBILITY_MODE,
+    resolve_ad_compatibility_mode,
+)
+
+
+@dataclass(frozen=True)
+class Capability:
+    """One modernized AD behavior described for runtime discovery.
+
+    Attributes:
+        name: Stable short identifier (for example ``"get-v2"``).
+        summary: One-sentence description of the behavior.
+        since_issue: GitHub issue number that introduced the behavior.
+        entry_points: Importable public symbols (``module:Name`` form).
+        legacy: Legacy API the behavior modernizes, or ``None`` if net-new.
+        migration: One-line legacy-to-v2 migration note.
+        example: Reference to a runnable example (repo path or in-package func).
+    """
+
+    name: str
+    summary: str
+    since_issue: int
+    entry_points: tuple[str, ...]
+    legacy: str | None
+    migration: str
+    example: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain, JSON-serializable ``dict`` of this capability."""
+
+        return {
+            "name": self.name,
+            "summary": self.summary,
+            "since_issue": self.since_issue,
+            "entry_points": list(self.entry_points),
+            "legacy": self.legacy,
+            "migration": self.migration,
+            "example": self.example,
+        }
+
+
+AD_CAPABILITIES: tuple[Capability, ...] = (
+    Capability(
+        name="compatibility-modes",
+        summary=(
+            "Select legacy/mixed/strict AD response shape via per-call, service, "
+            "or environment configuration."
+        ),
+        since_issue=18,
+        entry_points=(
+            "python_apis.apis:resolve_ad_compatibility_mode",
+            "python_apis.services:resolve_service_compatibility_mode",
+            "python_apis.apis:AD_COMPATIBILITY_MODES",
+        ),
+        legacy=None,
+        migration=(
+            "Set PYTHON_APIS_AD_COMPAT_MODE or pass compatibility_mode= to opt into "
+            "modern response fields; 'legacy' keeps historic behavior."
+        ),
+        example="python_apis.discovery.describe_compatibility_modes()",
+    ),
+    Capability(
+        name="operation-envelope",
+        summary=(
+            "Typed, dict-compatible AD operation/response envelope that mirrors "
+            "legacy keys while adding structured metadata."
+        ),
+        since_issue=19,
+        entry_points=(
+            "python_apis.models:ADOperationEnvelope",
+            "python_apis.models:ADResponse",
+        ),
+        legacy="dict with 'success'/'result'/'message' keys",
+        migration=(
+            "Modern fields are additive; existing response['success'] / "
+            "response.get('result') access keeps working."
+        ),
+        example="docs/migration/ad-operation-envelope.md",
+    ),
+    Capability(
+        name="error-taxonomy",
+        summary="Canonical AD error codes and a single resolver for operation outcomes.",
+        since_issue=20,
+        entry_points=(
+            "python_apis.services.error_taxonomy:AD_ERROR_CODES",
+            "python_apis.services.error_taxonomy:resolve_error_code",
+        ),
+        legacy="raw ldap3 exceptions / result dicts",
+        migration=(
+            "Classify failures with resolve_error_code(...) instead of matching "
+            "ldap3 exception types by hand."
+        ),
+        example="python_apis.migration_examples.error_handling_with_taxonomy()",
+    ),
+    Capability(
+        name="membership-apis",
+        summary="Transitive group membership and paged group-member reads.",
+        since_issue=22,
+        entry_points=(
+            "python_apis.services:ADGroupService.get_user_transitive_groups",
+            "python_apis.services:ADGroupService.get_group_members",
+            "python_apis.models:ADMembersPage",
+        ),
+        legacy="manual nested-group walking / unpaged member reads",
+        migration=(
+            "Use get_group_members(...) for an ADMembersPage with page_info / "
+            "has_next_page instead of reading 'member' directly."
+        ),
+        example="examples/membership_apis.py",
+    ),
+    Capability(
+        name="batch-read-v2",
+        summary=(
+            "Partial-failure-aware batch reads that surface failed records instead "
+            "of silently dropping them."
+        ),
+        since_issue=24,
+        entry_points=(
+            "python_apis.services:ADUserService.get_users_from_ad_v2",
+            "python_apis.services:ADGroupService.get_groups_from_ad_v2",
+            "python_apis.services:ADOrganizationalUnitService.get_ous_from_ad_v2",
+            "python_apis.models:ADBatchReadResult",
+        ),
+        legacy="get_users_from_ad / get_groups_from_ad / get_ous_from_ad (list)",
+        migration=(
+            "Switch to get_*_from_ad_v2 and read returned_items / failed_items "
+            "from the ADBatchReadResult envelope."
+        ),
+        example="examples/batch_read_v2.py",
+    ),
+    Capability(
+        name="multivalue-dual-form",
+        summary=(
+            "Dual-form AD multivalue attributes: raw value + normalized list + "
+            "source metadata."
+        ),
+        since_issue=25,
+        entry_points=(
+            "python_apis.models:ADMultiValue",
+            "python_apis.models:normalize_multivalue",
+        ),
+        legacy="comma-joined string from the schema layer",
+        migration=(
+            "Wrap raw values with normalize_multivalue(...); use as_legacy_string() "
+            "to reproduce the historic comma-joined string."
+        ),
+        example="examples/multivalue_dual_form.py",
+    ),
+    Capability(
+        name="get-v2",
+        summary=(
+            "Typed single-object read with an explicit found/not-found envelope."
+        ),
+        since_issue=26,
+        entry_points=(
+            "python_apis.apis:ADConnection.get_v2",
+            "python_apis.models:ADGetResult",
+        ),
+        legacy="python_apis.apis:ADConnection.get",
+        migration=(
+            "Replace get(...) with get_v2(...) and branch on result.found instead "
+            "of probing an empty default mapping."
+        ),
+        example="examples/get_v2.py",
+    ),
+)
+
+
+def list_capabilities() -> list[dict[str, Any]]:
+    """Return all modernized AD capabilities as JSON-serializable dicts."""
+
+    return [capability.to_dict() for capability in AD_CAPABILITIES]
+
+
+def get_capability(name: str) -> dict[str, Any]:
+    """Return one capability record by ``name``.
+
+    Args:
+        name: A capability identifier (see :func:`list_capabilities`).
+
+    Returns:
+        The capability record as a dict.
+
+    Raises:
+        KeyError: If ``name`` is unknown; the message lists available names.
+    """
+
+    for capability in AD_CAPABILITIES:
+        if capability.name == name:
+            return capability.to_dict()
+    available = ", ".join(capability.name for capability in AD_CAPABILITIES)
+    raise KeyError(f"Unknown capability '{name}'. Available: {available}")
+
+
+@dataclass(frozen=True)
+class _ModeInfo:
+    """Human-readable description of a single compatibility mode."""
+
+    intent: str
+    legacy_keys: str
+    modern_fields: str
+
+
+_MODE_INFO: dict[str, _ModeInfo] = {
+    "legacy": _ModeInfo(
+        intent="Preserve pre-modernization behavior (default).",
+        legacy_keys="present",
+        modern_fields="not added",
+    ),
+    "mixed": _ModeInfo(
+        intent="Modern fields plus legacy mirrors for a safe transition.",
+        legacy_keys="mirrored",
+        modern_fields="present",
+    ),
+    "strict": _ModeInfo(
+        intent="Modern fields only; legacy mirrors omitted.",
+        legacy_keys="omitted",
+        modern_fields="present",
+    ),
+}
+
+
+def active_compatibility_mode(
+    per_call_mode: str | None = None,
+    service_mode: str | None = None,
+) -> str:
+    """Return the effective AD compatibility mode for the current context.
+
+    Delegates to :func:`python_apis.apis.resolve_ad_compatibility_mode`, so the
+    precedence is ``per_call_mode`` -> ``service_mode`` -> environment variable
+    (``PYTHON_APIS_AD_COMPAT_MODE``) -> ``legacy``.
+
+    Args:
+        per_call_mode: Optional explicit override for this query.
+        service_mode: Optional service default to consider.
+
+    Returns:
+        One of ``"legacy"``, ``"mixed"``, or ``"strict"``.
+    """
+
+    return resolve_ad_compatibility_mode(
+        per_call_mode=per_call_mode,
+        service_mode=service_mode,
+    )
+
+
+def describe_compatibility_modes() -> dict[str, Any]:
+    """Return a structured description of the AD compatibility modes.
+
+    Returns:
+        A dict with the env var name, default mode, the active mode, and a
+        per-mode description of intent and legacy/modern field handling.
+    """
+
+    return {
+        "env_var": AD_COMPATIBILITY_ENV_VAR,
+        "default_mode": AD_DEFAULT_COMPATIBILITY_MODE,
+        "active_mode": active_compatibility_mode(),
+        "modes": {
+            mode: {
+                "intent": info.intent,
+                "legacy_keys": info.legacy_keys,
+                "modern_fields": info.modern_fields,
+            }
+            for mode, info in _MODE_INFO.items()
+        },
+    }
+
+
+def quick_reference() -> str:
+    """Return a printable cheat sheet for the modernized AD behaviors.
+
+    The string names the compatibility modes and env var, the active mode, and
+    each capability with its primary entry point and migration note, so the
+    whole surface is discoverable from a single REPL call.
+    """
+
+    lines: list[str] = [
+        "python_apis - AD modernization quick reference",
+        "=" * 46,
+        "",
+        f"Compatibility env var : {AD_COMPATIBILITY_ENV_VAR}",
+        f"Modes                 : {', '.join(AD_COMPATIBILITY_MODES)} "
+        f"(default: {AD_DEFAULT_COMPATIBILITY_MODE})",
+        f"Active mode           : {active_compatibility_mode()}",
+        "",
+        "Capabilities (legacy -> v2):",
+    ]
+    for capability in AD_CAPABILITIES:
+        primary = capability.entry_points[0] if capability.entry_points else "-"
+        legacy = capability.legacy or "(net-new)"
+        lines.append(f"  - {capability.name} (#{capability.since_issue})")
+        lines.append(f"      {capability.summary}")
+        lines.append(f"      from   : {legacy}")
+        lines.append(f"      use    : {primary}")
+        lines.append(f"      hint   : {capability.migration}")
+    lines.append("")
+    lines.append(
+        "Discover more: python_apis.discovery.list_capabilities(), "
+        "describe_compatibility_modes(); python_apis.migration_examples.print_all()."
+    )
+    return "\n".join(lines)
+
+
+def print_quick_reference() -> None:
+    """Print the :func:`quick_reference` cheat sheet to stdout."""
+
+    print(quick_reference())
+
+
+__all__ = [
+    "Capability",
+    "AD_CAPABILITIES",
+    "list_capabilities",
+    "get_capability",
+    "active_compatibility_mode",
+    "describe_compatibility_modes",
+    "quick_reference",
+    "print_quick_reference",
+]

--- a/src/python_apis/migration_examples.py
+++ b/src/python_apis/migration_examples.py
@@ -1,0 +1,129 @@
+"""Connection-free before/after migration snippets (issue #27).
+
+Each function returns a self-contained string showing the legacy approach and
+its modern replacement side by side. The snippets are plain text, require no AD
+connection, and are safe to print in a REPL, embed in docs, or surface from
+tooling. They complement :mod:`python_apis.discovery` (machine-readable
+capability registry) with copy-pasteable code.
+
+Example:
+    >>> from python_apis import migration_examples
+    >>> print(migration_examples.legacy_get_to_get_v2())  # doctest: +ELLIPSIS
+    # Legacy: ambiguous empty-default mapping...
+"""
+
+
+def legacy_get_to_get_v2() -> str:
+    """Migrating ``ADConnection.get`` to the typed ``get_v2`` envelope."""
+
+    return (
+        "# Legacy: ambiguous empty-default mapping\n"
+        "obj = conn.get('(sAMAccountName=jdoe)', ['cn'])\n"
+        "if obj.get('cn'):\n"
+        "    use(obj)\n"
+        "\n"
+        "# Modern: explicit found flag via ADGetResult\n"
+        "res = conn.get_v2('(sAMAccountName=jdoe)', ['cn'])\n"
+        "if res.found:\n"
+        "    use(res.item)\n"
+        "else:\n"
+        "    handle_missing(res.not_found_reason)"
+    )
+
+
+def list_read_to_batch_v2() -> str:
+    """Migrating silent-drop list reads to the partial-failure batch result."""
+
+    return (
+        "# Legacy: invalid records are logged and silently dropped\n"
+        "users = service.get_users_from_ad('(objectClass=user)')\n"
+        "\n"
+        "# Modern: inspect successes and structured failures\n"
+        "result = service.get_users_from_ad_v2('(objectClass=user)')\n"
+        "for user in result.returned_items:\n"
+        "    use(user)\n"
+        "for failure in result.failed_items:\n"
+        "    report(failure)"
+    )
+
+
+def raw_multivalue_to_dual_form() -> str:
+    """Migrating ad-hoc multi-value parsing to ``normalize_multivalue``."""
+
+    return (
+        "# Legacy: manual split on a delimiter, lossy for binary values\n"
+        "groups = raw['memberOf'].split(';') if raw.get('memberOf') else []\n"
+        "\n"
+        "# Modern: dual-form values keep both list and legacy string\n"
+        "from python_apis.models import normalize_multivalue\n"
+        "mv = normalize_multivalue(raw.get('memberOf'))\n"
+        "groups = mv.values             # list form\n"
+        "legacy = mv.as_legacy_string()  # verbatim legacy string"
+    )
+
+
+def error_handling_with_taxonomy() -> str:
+    """Mapping ad-hoc exception handling to the shared error taxonomy."""
+
+    return (
+        "# Legacy: stringly-typed, ad-hoc exception branching\n"
+        "try:\n"
+        "    conn.add(...)\n"
+        "except Exception as exc:  # noqa: BLE001\n"
+        "    if 'already exists' in str(exc):\n"
+        "        ...\n"
+        "\n"
+        "# Modern: stable error codes from the taxonomy\n"
+        "from python_apis.services.error_taxonomy import map_exception_to_error_code\n"
+        "try:\n"
+        "    conn.add(...)\n"
+        "except Exception as exc:  # noqa: BLE001\n"
+        "    code = map_exception_to_error_code(exc)\n"
+        "    handle(code)"
+    )
+
+
+def compatibility_mode_selection() -> str:
+    """Choosing and inspecting the active AD compatibility mode."""
+
+    return (
+        "# Inspect the active mode and how it was resolved\n"
+        "from python_apis import discovery\n"
+        "info = discovery.describe_compatibility_modes()\n"
+        "print(info['active_mode'], 'from', info['env_var'])\n"
+        "\n"
+        "# Opt a single call into a stricter modern shape\n"
+        "service.get_users_from_ad_v2(compatibility_mode='strict')"
+    )
+
+
+def all_examples() -> dict[str, str]:
+    """Return every migration snippet keyed by a stable identifier."""
+
+    return {
+        "legacy_get_to_get_v2": legacy_get_to_get_v2(),
+        "list_read_to_batch_v2": list_read_to_batch_v2(),
+        "raw_multivalue_to_dual_form": raw_multivalue_to_dual_form(),
+        "error_handling_with_taxonomy": error_handling_with_taxonomy(),
+        "compatibility_mode_selection": compatibility_mode_selection(),
+    }
+
+
+def print_all() -> None:
+    """Print every migration snippet with a labeled header."""
+
+    for name, snippet in all_examples().items():
+        print(f"=== {name} ===")
+        print(snippet)
+        print()
+
+
+__all__ = [
+    "legacy_get_to_get_v2",
+    "list_read_to_batch_v2",
+    "raw_multivalue_to_dual_form",
+    "error_handling_with_taxonomy",
+    "compatibility_mode_selection",
+    "all_examples",
+    "print_all",
+]

--- a/src/python_apis/services/ad_user_service.py
+++ b/src/python_apis/services/ad_user_service.py
@@ -183,6 +183,24 @@ class ADUserService:
     ) -> list[ADUser]:
         """Retrieve users from Active Directory based on a search filter.
 
+        For new code prefer :meth:`get_users_from_ad_v2`, which returns a
+        structured batch result that surfaces per-record failures instead of
+        silently dropping records that fail validation.
+
+        Before (legacy, silent drops)::
+
+            users = service.get_users_from_ad("(objectClass=user)")
+            # invalid records are logged and omitted; callers cannot tell
+
+        After (structured, inspectable)::
+
+            result = service.get_users_from_ad_v2("(objectClass=user)")
+            for failure in result.failed_items:
+                handle(failure)
+
+        See ``python_apis.discovery.get_capability('batch-read-v2')`` and
+        ``python_apis.migration_examples.list_read_to_batch_v2()``.
+
         Args:
             search_filter (str): LDAP search filter. Defaults to '(objectClass=user)'.
 

--- a/src/tests/test_apis/test_ad_api.py
+++ b/src/tests/test_apis/test_ad_api.py
@@ -90,6 +90,16 @@ class TestADConnection(unittest.TestCase):
 
         self.assertEqual(result['cn'], '')  # defaultdict returns empty string
 
+    def test_get_emits_deprecation_warning(self):
+        ad_conn = ADConnection(self.servers, self.search_base)
+        mock_result = [{'attributes': {'cn': 'John Doe'}}]
+        self.mock_connection.extend.standard.paged_search.return_value = iter(mock_result)
+
+        with self.assertWarns(DeprecationWarning) as ctx:
+            ad_conn.get('(objectClass=user)', ['cn'])
+
+        self.assertIn('get_v2', str(ctx.warning))
+
     def test_get_v2_with_results(self):
         ad_conn = ADConnection(self.servers, self.search_base)
         mock_result = [{'attributes': {'cn': 'John Doe'}}]

--- a/src/tests/test_deprecation.py
+++ b/src/tests/test_deprecation.py
@@ -1,0 +1,73 @@
+"""Tests for the structured deprecation helper (issue #27)."""
+
+import unittest
+import warnings
+
+from python_apis.deprecation import build_legacy_message, warn_legacy
+
+
+class TestBuildLegacyMessage(unittest.TestCase):
+    """Validate message composition."""
+
+    def test_message_names_legacy_replacement_and_hint(self):
+        message = build_legacy_message(
+            "ADConnection.get",
+            replacement="ADConnection.get_v2",
+            migration_hint="Branch on result.found.",
+        )
+        self.assertIn("ADConnection.get", message)
+        self.assertIn("ADConnection.get_v2", message)
+        self.assertIn("Branch on result.found.", message)
+
+    def test_message_includes_since_when_provided(self):
+        message = build_legacy_message(
+            "old",
+            replacement="new",
+            migration_hint="do it",
+            since="#26",
+        )
+        self.assertIn("#26", message)
+
+    def test_message_omits_since_marker_when_absent(self):
+        message = build_legacy_message(
+            "old",
+            replacement="new",
+            migration_hint="do it",
+        )
+        self.assertNotIn("since", message)
+
+
+class TestWarnLegacy(unittest.TestCase):
+    """Validate warning emission and returned message."""
+
+    def test_warn_legacy_emits_deprecation_warning(self):
+        with self.assertWarns(DeprecationWarning):
+            warn_legacy(
+                "old",
+                replacement="new",
+                migration_hint="do it",
+            )
+
+    def test_warn_legacy_returns_emitted_message(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            message = warn_legacy(
+                "old",
+                replacement="new",
+                migration_hint="do it",
+            )
+        self.assertEqual(len(caught), 1)
+        self.assertEqual(str(caught[0].message), message)
+
+    def test_warn_legacy_respects_category(self):
+        with self.assertWarns(FutureWarning):
+            warn_legacy(
+                "old",
+                replacement="new",
+                migration_hint="do it",
+                category=FutureWarning,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_discovery.py
+++ b/src/tests/test_discovery.py
@@ -1,0 +1,103 @@
+"""Tests for the in-package discovery toolkit (issue #27)."""
+
+import importlib
+import unittest
+
+from python_apis import discovery
+
+
+def _resolve_entry_point(entry_point: str):
+    """Import ``module:dotted.attr`` and return the resolved object."""
+
+    module_path, _, attr_path = entry_point.partition(":")
+    obj = importlib.import_module(module_path)
+    for part in attr_path.split("."):
+        obj = getattr(obj, part)
+    return obj
+
+
+class TestCapabilityRegistry(unittest.TestCase):
+    """Validate the capability registry shape and entry-point integrity."""
+
+    def test_list_capabilities_returns_dicts_with_expected_keys(self):
+        capabilities = discovery.list_capabilities()
+        self.assertGreater(len(capabilities), 0)
+        expected_keys = {
+            "name",
+            "summary",
+            "since_issue",
+            "entry_points",
+            "legacy",
+            "migration",
+            "example",
+        }
+        for capability in capabilities:
+            self.assertEqual(set(capability), expected_keys)
+            self.assertIsInstance(capability["name"], str)
+            self.assertIsInstance(capability["entry_points"], list)
+            self.assertTrue(capability["entry_points"])
+
+    def test_capability_names_are_unique(self):
+        names = [cap["name"] for cap in discovery.list_capabilities()]
+        self.assertEqual(len(names), len(set(names)))
+
+    def test_every_entry_point_is_importable(self):
+        for capability in discovery.list_capabilities():
+            for entry_point in capability["entry_points"]:
+                with self.subTest(entry_point=entry_point):
+                    self.assertIsNotNone(_resolve_entry_point(entry_point))
+
+    def test_legacy_entry_points_are_importable_when_present(self):
+        for capability in discovery.list_capabilities():
+            legacy = capability["legacy"]
+            if legacy and ":" in legacy:
+                with self.subTest(legacy=legacy):
+                    self.assertIsNotNone(_resolve_entry_point(legacy))
+
+    def test_get_capability_returns_matching_record(self):
+        record = discovery.get_capability("get-v2")
+        self.assertEqual(record["name"], "get-v2")
+        self.assertEqual(record["since_issue"], 26)
+
+    def test_get_capability_unknown_name_raises_keyerror_with_options(self):
+        with self.assertRaises(KeyError) as ctx:
+            discovery.get_capability("does-not-exist")
+        self.assertIn("Available:", str(ctx.exception))
+
+
+class TestCompatibilityModeIntrospection(unittest.TestCase):
+    """Validate mode introspection helpers."""
+
+    def test_active_compatibility_mode_returns_known_mode(self):
+        mode = discovery.active_compatibility_mode()
+        self.assertIn(mode, ("legacy", "mixed", "strict"))
+
+    def test_active_compatibility_mode_honors_per_call_override(self):
+        self.assertEqual(
+            discovery.active_compatibility_mode(per_call_mode="strict"),
+            "strict",
+        )
+
+    def test_describe_compatibility_modes_shape(self):
+        described = discovery.describe_compatibility_modes()
+        self.assertIn("env_var", described)
+        self.assertIn("default_mode", described)
+        self.assertIn("active_mode", described)
+        self.assertEqual(
+            set(described["modes"]),
+            {"legacy", "mixed", "strict"},
+        )
+
+
+class TestQuickReference(unittest.TestCase):
+    """Validate the printable quick reference."""
+
+    def test_quick_reference_is_non_empty_and_mentions_capabilities(self):
+        text = discovery.quick_reference()
+        self.assertTrue(text.strip())
+        for capability in discovery.list_capabilities():
+            self.assertIn(capability["name"], text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_migration_examples.py
+++ b/src/tests/test_migration_examples.py
@@ -1,0 +1,43 @@
+"""Tests for the in-package migration examples (issue #27)."""
+
+import unittest
+
+from python_apis import migration_examples
+
+
+class TestMigrationExamples(unittest.TestCase):
+    """Validate that every example returns a non-empty snippet."""
+
+    def test_all_examples_returns_non_empty_strings(self):
+        examples = migration_examples.all_examples()
+        self.assertTrue(examples)
+        for name, snippet in examples.items():
+            with self.subTest(example=name):
+                self.assertIsInstance(snippet, str)
+                self.assertTrue(snippet.strip())
+
+    def test_each_example_function_returns_non_empty_string(self):
+        for func in (
+            migration_examples.legacy_get_to_get_v2,
+            migration_examples.list_read_to_batch_v2,
+            migration_examples.raw_multivalue_to_dual_form,
+            migration_examples.error_handling_with_taxonomy,
+            migration_examples.compatibility_mode_selection,
+        ):
+            with self.subTest(func=func.__name__):
+                self.assertTrue(func().strip())
+
+    def test_all_in_dunder_all_are_exported(self):
+        for name in migration_examples.__all__:
+            self.assertTrue(hasattr(migration_examples, name))
+
+    def test_get_v2_example_mentions_modern_api(self):
+        self.assertIn("get_v2", migration_examples.legacy_get_to_get_v2())
+
+    def test_print_all_runs_without_error(self):
+        # Should not raise; output is not asserted here.
+        migration_examples.print_all()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Stage N+1 of the AD modernization (ADR 0001): make the modernized, additive AD behaviors discoverable from the Python REPL and IDE alone, without a round-trip to `docs/migration/` or `docs/adr/`. All changes are additive — no signatures or behaviors of existing APIs change (legacy `ADConnection.get` only gains an informational `DeprecationWarning`).

Closes #27

## Changes

- **`python_apis.discovery`** (new) — runtime capability registry (`list_capabilities`, `get_capability`) covering compatibility-modes (#18), operation-envelope (#19), error-taxonomy (#20), membership-apis (#22), batch-read-v2 (#24), multivalue-dual-form (#25), get-v2 (#26); compatibility-mode introspection (`active_compatibility_mode`, `describe_compatibility_modes`); and a printable `quick_reference`/`print_quick_reference` cheat sheet.
- **`python_apis.deprecation`** (new) — `warn_legacy` / `build_legacy_message` emit a one-line, actionable `DeprecationWarning`. Wired into legacy `ADConnection.get` pointing at `get_v2` (behavior otherwise unchanged).
- **`python_apis.migration_examples`** (new) — connection-free before/after snippets (`legacy_get_to_get_v2`, `list_read_to_batch_v2`, `raw_multivalue_to_dual_form`, `error_handling_with_taxonomy`, `compatibility_mode_selection`) plus `all_examples()`/`print_all()`.
- **Docstrings** — before/after migration pointers added to legacy `ADConnection.get` and `ADUserService.get_users_from_ad`.
- **Exports** — `discovery`, `deprecation`, `migration_examples` added to top-level `python_apis.__all__`.
- **Tests** — new `test_discovery.py`, `test_deprecation.py`, `test_migration_examples.py`, plus a legacy-`get` deprecation-warning test in `test_ad_api.py`. A drift-guard test imports every registry entry point so the registry can't silently go stale.
- **CHANGELOG** — Unreleased → Added entry.

## Testing

- `.\venv\Scripts\python.exe -m pylint src/python_apis/` → **10.00/10**
- `.\venv\Scripts\python.exe -m unittest discover -s src/tests -p "test_*.py"` → **298 tests, OK**
- Manual: `from python_apis import discovery; discovery.print_quick_reference()` and `from python_apis import migration_examples; migration_examples.print_all()`.

## SemVer

**`semver:minor`** — purely additive: new modules/exports and an informational `DeprecationWarning` on legacy `get`; no existing signatures or behaviors change.