### PR TITLE
ci(#29): add PR-time SemVer label validation check

### DIFF
--- a/.github/workflows/Test and publish.yml
+++ b/.github/workflows/Test and publish.yml
@@ -20,17 +20,26 @@ jobs:
         set -euo pipefail
 
         semver_labels=$(printf '%s' "$PR_LABELS" | jq -r '.[] | select(startswith("semver:"))')
+        semver_labels=$(printf '%s\n' "$semver_labels" | sed '/^$/d')
 
         semver_count=$(printf '%s\n' "$semver_labels" | sed '/^$/d' | wc -l | tr -d ' ')
+        labels_display=$(printf '%s' "$semver_labels" | paste -sd ',' -)
         if [ "$semver_count" -ne 1 ]; then
-          echo "::error::PR #$PR_NUMBER must have exactly one SemVer label: semver:major, semver:minor, or semver:none."
-          echo "::error::Found ${semver_count} SemVer label(s): ${semver_labels:-<none>}"
-          echo "::error::See the Versioning and Release Flow section in README.md."
+          echo "::error::PR #$PR_NUMBER must have exactly one SemVer label (semver:major, semver:minor, or semver:none)."
+          echo "::error::Found ${semver_count} SemVer label(s): ${labels_display:-<none>}. See the Versioning and Release Flow section in README.md."
           exit 1
         fi
 
-        semver_label=$(printf '%s\n' "$semver_labels" | sed '/^$/d')
-        echo "PR #$PR_NUMBER has a valid SemVer label: $semver_label"
+        case "$semver_labels" in
+          semver:major|semver:minor|semver:none)
+            echo "PR #$PR_NUMBER has a valid SemVer label: $semver_labels"
+            ;;
+          *)
+            echo "::error::PR #$PR_NUMBER has an unsupported SemVer label: $semver_labels."
+            echo "::error::Allowed SemVer labels are semver:major, semver:minor, or semver:none. See the Versioning and Release Flow section in README.md."
+            exit 1
+            ;;
+        esac
 
   check-links:
     runs-on: ubuntu-latest

--- a/.github/workflows/Test and publish.yml
+++ b/.github/workflows/Test and publish.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   validate-semver-label:
@@ -13,13 +14,12 @@ jobs:
     steps:
     - name: Require exactly one SemVer label
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
       run: |
         set -euo pipefail
 
-        semver_labels=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
-          --jq '.labels[].name | select(startswith("semver:"))')
+        semver_labels=$(printf '%s' "$PR_LABELS" | jq -r '.[] | select(startswith("semver:"))')
 
         semver_count=$(printf '%s\n' "$semver_labels" | sed '/^$/d' | wc -l | tr -d ' ')
         if [ "$semver_count" -ne 1 ]; then
@@ -34,6 +34,7 @@ jobs:
 
   check-links:
     runs-on: ubuntu-latest
+    if: github.event.action != 'labeled' && github.event.action != 'unlabeled'
     steps:
     - uses: actions/checkout@v4.2.2
 
@@ -52,6 +53,7 @@ jobs:
 
   test:
     runs-on: windows-latest
+    if: github.event.action != 'labeled' && github.event.action != 'unlabeled'
     strategy:
       matrix:
         python-version: ['3.12', '3.14']

--- a/.github/workflows/Test and publish.yml
+++ b/.github/workflows/Test and publish.yml
@@ -7,6 +7,31 @@ on:
     branches: [main]
 
 jobs:
+  validate-semver-label:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+    - name: Require exactly one SemVer label
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        set -euo pipefail
+
+        semver_labels=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+          --jq '.labels[].name | select(startswith("semver:"))')
+
+        semver_count=$(printf '%s\n' "$semver_labels" | sed '/^$/d' | wc -l | tr -d ' ')
+        if [ "$semver_count" -ne 1 ]; then
+          echo "::error::PR #$PR_NUMBER must have exactly one SemVer label: semver:major, semver:minor, or semver:none."
+          echo "::error::Found ${semver_count} SemVer label(s): ${semver_labels:-<none>}"
+          echo "::error::See the Versioning and Release Flow section in README.md."
+          exit 1
+        fi
+
+        semver_label=$(printf '%s\n' "$semver_labels" | sed '/^$/d')
+        echo "PR #$PR_NUMBER has a valid SemVer label: $semver_label"
+
   check-links:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- PR-time `validate-semver-label` CI check (issue #29, `semver:none`) that fails a pull request
+  early when it is missing a SemVer label or has more than one, before merge.
 - In-package discoverability toolkit for the modernized AD surface (issue #27): `python_apis.discovery` (capability registry via `list_capabilities`/`get_capability` and a printable `quick_reference`), `python_apis.deprecation` (`warn_legacy` structured migration warnings), and `python_apis.migration_examples` (connection-free before/after snippets). All additive (`semver:minor`).
 - rename_user_cn functionality to ADUserService for renaming user common names
 - Python 3.14 support and optimized CI/CD workflows  

--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ This project uses label-driven SemVer for releases from `main`.
   - `semver:none` -> no version bump and no publish.
 - The publish workflow resolves the bump type from the merged PR label and fails if the label is
   missing or ambiguous.
+- PR CI also runs a `validate-semver-label` check that fails early when a pull request is missing a
+  SemVer label or has more than one, so labeling problems are caught before merge.
 - Breaking changes must use `semver:major`.
 
 Examples:


### PR DESCRIPTION
## Description

The publish workflow derives the version bump from the merged PR's SemVer label, but that
validation only runs in the `publish` job on push to `main`. By then a mislabeled PR is already
merged and the release fails late. This adds a pre-merge check so labeling problems are caught
during PR CI.

Closes #29

## Changes

- Added a `validate-semver-label` job to `.github/workflows/Test and publish.yml` that runs only on
  `pull_request` events, reads PR labels via `gh`, and fails when zero or more than one `semver:*`
  label is present (passes on exactly one).
- Documented the PR-time check in the README "Versioning and Release Flow" section.
- Added a `CHANGELOG.md` entry under Unreleased → Added.

## Testing

- Validated the workflow YAML parses (`yaml.safe_load`).
- Job logic mirrors the existing publish-time resolution: counts `semver:*` labels and exits
  non-zero unless exactly one is present, emitting actionable `::error::` messages.

Acceptance criteria:
- PR without a SemVer label fails the check.
- PR with multiple SemVer labels fails the check.
- PR with exactly one SemVer label passes.
- Job is skipped on `push` events.

**SemVer impact:** `semver:none` (workflow governance only).
